### PR TITLE
Add docs about decision around, and alternatives to, testID

### DIFF
--- a/Best practices/Testing.md
+++ b/Best practices/Testing.md
@@ -21,7 +21,7 @@ Below are some specific applications of this principle:
 
 * Do not over-mock. Mocking can be a useful tool for short-circuiting potentially expensive function calls or for more easily simulating a particular environment. However, overuse of mocks reduces the degree to which the tests represent the running system, and can indicate a design that has been excessively broken up solely for the purposes of being able to inject mocks into various points of the operation.
 
-* Do not rely on test IDs of any kind. See the [test IDs](#test-ids) section below for alternative to test IDs, and read additional rationale for this decision in its [decision record](../Decision%20records/04%20-%20We%20do%20not%20use%20test%20IDs%20in%20tests.md).
+* Do not rely on test IDs of any kind. See the [test IDs](#test-ids) section below for alternative to test IDs, and read additional rationale for this decision in its [decision record](../Decision%20records/04%20-%20We%20do%20not%20use%20test%20IDs.md).
 
 ### Setup, perform, assert
 
@@ -221,7 +221,7 @@ A common way in which developers accidentally break the barrier of public API in
 * Markup that has an important effect on the visual output of a component, but which have no other defining characteristics (for example, an element on which we apply a particular class name or inline styles).
 * A child component that is rendered multiple times, where the developer wishes to easily disambiguate between the instances (for example, a component that renders multiple `Modal`s from Polaris React).
 
-We would like to avoid test IDs for handling the cases above, as make it easy to reach into your component in ways that unnecessarily lock down the implementation. You can typically avoid test IDs by using one of the following strategies:
+We would like to avoid test IDs for handling the cases above, as they make it easy to reach into your component in ways that unnecessarily lock down the implementation. You can typically avoid test IDs by using one of the following strategies:
 
 * If you are asserting that particular text exists in your component, simply check that the text exists *somewhere* in the component without noting a particular element that contains it. For example, you could do the following in Enzyme to assert that a particular string exists based on a `name` prop passed to a React component:
 

--- a/Decision records/04 - We do not use test IDs in tests.md
+++ b/Decision records/04 - We do not use test IDs in tests.md
@@ -1,0 +1,49 @@
+# We do not use test IDs in tests
+
+## Date
+
+July 10, 2018
+
+## Contributors
+
+* Chris Sauvé
+* Mallory Allen
+
+## Summary
+
+Test IDs make it too easy to test implementation details of components. They should be avoided in favor of [alternatives](../Best%20practices/Testing.md#test-ids) that emphasize the guarantees a component actually makes.
+
+## Description
+
+Developers sometimes feel the need to add "hooks" that allow their tests to easily find parts of the component subtree and assert details about those subtrees in tests. In the React ecosystem, this is a key recommendation of an alternative to Enzyme (our preferred React testing library), [`react-testing-library`/ `dom-testing-library`](https://github.com/kentcdodds/dom-testing-library/blob/master/README.md#faq).
+
+## History
+
+In building the initial version of Shopify Web, we took several steps to encourage and facilitate the use of test IDs:
+
+* A [babel plugin](https://github.com/lemonmade/babel-plugin-react-test-id) to remove the unnecessary attribute in production
+* Allowing the `testID` prop implicitly with TypeScript and adding a `findByTestId` utility to Shopify Web
+
+These were originally introduced to facilitate differentiation between the same React component rendered multiple times within a tree (specifically, to target multiple `TextField` components rendered by a card in the product section of the admin). No analysis of alternatives was performed at the time. The cases in which this attribute was used expanded and, as of July 10, 2018, it is used 280 times in the Web codebase.
+
+## Decision
+
+`testID` provides some benefits that have made it attractive to developers working in the Web stack:
+
+* It clearly indicates its intent: it is meant to identify an element exclusively for tests
+* Our implementation in Shopify Web allows it to be used on any HTML element or custom component (without changes to the component’s API)
+* It has no runtime impact because the attribute is stripped in production builds
+
+However, implementing `testID` for a project involves several steps, and all of them are clearly monkey patches:
+
+* You must augment an internal React interface for TypeScript to not complain about the unexpected attribute
+* You must prevent console warnings that React prints by default complaining about an unexpected `testID` prop on DOM elements
+* You must be sure to include our custom Babel plugin to strip the attribute in production builds
+
+Additionally, in reviewing the use of `testID` in Web, we found that the ways it were used were better addressed using other strategies. We have detailed common patterns we found (along with alternative strategies to `testID`) in our [testing best practices](../Best%20practices/Testing.md#test-ids), but in summary, we found that `testID` was used to:
+
+* Filter a collection of the same component (`TextField`, `Modal`, etc), where it would be preferable either to create a component that composes each individual component, or filter on the `id` or other "true" property that was unique between the instances,
+* Find a wrapper around text they wanted to assert was present, where asserting that the content appeared anywhere in the component would suffice, or
+* Find a DOM node that was not semantically important for the test, but which allowed them to partially assert something about the visual fidelity of the component
+
+Given the downsides noted above, and the fact that we have preferred alternative approaches to all common use cases for `testID`, we discourage the use of this and similar attributes in all projects.

--- a/Decision records/04 - We do not use test IDs.md
+++ b/Decision records/04 - We do not use test IDs.md
@@ -1,4 +1,4 @@
-# We do not use test IDs in tests
+# We do not use test IDs
 
 ## Date
 
@@ -15,16 +15,21 @@ Test IDs make it too easy to test implementation details of components. They sho
 
 ## Description
 
-Developers sometimes feel the need to add "hooks" that allow their tests to easily find parts of the component subtree and assert details about those subtrees in tests. In the React ecosystem, this is a key recommendation of an alternative to Enzyme (our preferred React testing library), [`react-testing-library`/ `dom-testing-library`](https://github.com/kentcdodds/dom-testing-library/blob/master/README.md#faq).
+Developers sometimes feel the need to add "hooks" that allow their tests to easily find parts of the component subtree and assert details about those subtrees in tests. `testID` (or related properties, such as `data-test-id`) are commonly used for this purpose.
 
 ## History
 
 In building the initial version of Shopify Web, we took several steps to encourage and facilitate the use of test IDs:
 
 * A [babel plugin](https://github.com/lemonmade/babel-plugin-react-test-id) to remove the unnecessary attribute in production
-* Allowing the `testID` prop implicitly with TypeScript and adding a `findByTestId` utility to Shopify Web
+* Allowing the `testID` prop implicitly within TypeScript in Shopify Web
+* Adding a `findByTestId` utility to Shopify Web to make it easier to find nodes by this property
 
-These were originally introduced to facilitate differentiation between the same React component rendered multiple times within a tree (specifically, to target multiple `TextField` components rendered by a card in the product section of the admin). No analysis of alternatives was performed at the time. The cases in which this attribute was used expanded and, as of July 10, 2018, it is used 280 times in the Web codebase.
+These were originally introduced to facilitate differentiation between the same React component rendered multiple times within a tree. No analysis of alternatives was performed at the time. The cases in which this attribute was used expanded and, as of July 10, 2018, it is used 280 times in the Shopify Web codebase.
+
+## Community
+
+In the React ecosystem, the use of `data-testid` is a key recommendation of an alternative to Enzyme (our preferred React testing library), [`react-testing-library`/ `dom-testing-library`](https://github.com/kentcdodds/dom-testing-library/blob/master/README.md#faq). There does not seem to be a strong consensus for or against test IDs elsewhere in the industry.
 
 ## Decision
 
@@ -40,9 +45,9 @@ However, implementing `testID` for a project involves several steps, and all of 
 * You must prevent console warnings that React prints by default complaining about an unexpected `testID` prop on DOM elements
 * You must be sure to include our custom Babel plugin to strip the attribute in production builds
 
-Additionally, in reviewing the use of `testID` in Web, we found that the ways it were used were better addressed using other strategies. We have detailed common patterns we found (along with alternative strategies to `testID`) in our [testing best practices](../Best%20practices/Testing.md#test-ids), but in summary, we found that `testID` was used to:
+Additionally, in reviewing the use of `testID` in Shopify Web, we found that the ways it were used were better addressed using other strategies. We have detailed common patterns we found (along with alternative strategies to `testID`) in our [testing best practices](../Best%20practices/Testing.md#test-ids), but in summary, we found that `testID` was used to:
 
-* Filter a collection of the same component (`TextField`, `Modal`, etc), where it would be preferable either to create a component that composes each individual component, or filter on the `id` or other "true" property that was unique between the instances,
+* Filter a collection of the same component (`TextField`, `Modal`, etc), where it would be preferable either to create a component that composes each individual component, or filter on the `id` or other "true" property that was unique between the instances (`id` is particularly desirable as it can provide a stable identifier for things like tracking),
 * Find a wrapper around text they wanted to assert was present, where asserting that the content appeared anywhere in the component would suffice, or
 * Find a DOM node that was not semantically important for the test, but which allowed them to partially assert something about the visual fidelity of the component
 


### PR DESCRIPTION
Does what it says on the tin. I wanted to get this down into words so people understand why we are mostly opposed to the use of this attribute, provide some historical context for why we have so many in the existing Web app, and give people alternatives for the common patterns I have seen.

cc/ @Shopify/web-foundation 