### PR TITLE
Fix broken links in testing guide

### DIFF
--- a/Best practices/Enzyme.md
+++ b/Best practices/Enzyme.md
@@ -50,7 +50,7 @@ We have one utility package for Enzyme, [@shopify/enzyme-utilities](https://gith
 
 ## Expectations
 
-As noted in our [main testing guide](../Testing), you should prefer the “smartest” assertions available. When making heavy use of Enzyme and Jest, we recommend including [enzyme-matchers](https://github.com/FormidableLabs/enzyme-matchers), which provide more meaningful assertions for Enzyme wrappers. Below are a couple of common examples where these smarter assertions are useful:
+As noted in our [main testing guide](./Testing.md), you should prefer the “smartest” assertions available. When making heavy use of Enzyme and Jest, we recommend including [enzyme-matchers](https://github.com/FormidableLabs/enzyme-matchers), which provide more meaningful assertions for Enzyme wrappers. Below are a couple of common examples where these smarter assertions are useful:
 
 ```js
 const myComponent = mount(<MyComponent />);

--- a/Best practices/Jest.md
+++ b/Best practices/Jest.md
@@ -98,7 +98,7 @@ We have a number of packages that handle common mocking scenarios that are built
 
 ## Expectations
 
-As noted in our [main testing guide](../Testing.md), you should prefer the “smartest” assertions available. Below are some common examples of applying this rule to Jest (note that you can always visit the [Jest expect guide](https://facebook.github.io/jest/docs/en/expect.html) for a list of available assertions).
+As noted in our [main testing guide](./Testing.md), you should prefer the “smartest” assertions available. Below are some common examples of applying this rule to Jest (note that you can always visit the [Jest expect guide](https://facebook.github.io/jest/docs/en/expect.html) for a list of available assertions).
 
 ```js
 // .toHaveProperty()


### PR DESCRIPTION
I was reading through the testing guide using GitHub and noticed some broken links. Broken links makes me a 😢🐼 Hopefully these are where they're supposed to link to.