### PR TITLE
July 30 meeting decisions

### DIFF
--- a/Best practices/React/Testing.md
+++ b/Best practices/React/Testing.md
@@ -163,3 +163,46 @@ Another benefit of testing React components is that they typically abstract away
     });
   });
   ```
+
+* If you find that you need to share utilities between test files (for example, because you have split a single component’s tests among several files), put them in the nearest shared `tests/utilities` directory. This differentiated test files from "support" files, and mirrors how we store fixtures.
+
+  ```
+  # Bad
+  MyComponent/
+  └── tests
+      ├── feature-one.test.tsx
+      ├── feature-two.test.tsx
+      └── utilities.ts
+
+  # Good
+  MyComponent/
+  └── tests
+      ├── feature-one.test.tsx
+      ├── feature-two.test.tsx
+      └── utilities/
+          └── index.ts
+  ```
+
+### Split test files
+
+As noted in the [decision record](../../Decision%20records/06%20-%20We%20split%20up%20large%20component%20test%20files%20by%20feature.md), when a component’s test file gets large enough that is hard to navigate and/ or stresses editor tooling, we split the test file by feature. Below are some best practices for naming and structure of these split files:
+
+* Name the split files in the format `component-feature.test.tsx`. For example, a test file for the SEO feature of a `ProductDetails` component would be found at `ProductDetails/tests/seo.test.tsx`.
+* Tests that do not directly relate to a particular feature, or are too small to warrant a separate test file, should remain in a test file named after the component (for example, `ProductDetails/tests/ProductDetails.test.tsx`).
+* Nest all tests for a component in a describe block named after the component, followed by a describe block for the feature. This allows the results to be grouped together by the test runner.
+
+  ```ts
+  // seo.test.tsx
+  describe('<ProductIndex />', () => {
+    describe('seo', () => {
+      // tests
+    });
+  });
+
+  // images.test.tsx
+  describe('<ProductIndex />', () => {
+    describe('images', () => {
+      // tests
+    });
+  });
+  ```

--- a/Best practices/React/Testing.md
+++ b/Best practices/React/Testing.md
@@ -192,15 +192,15 @@ As noted in the [decision record](../../Decision%20records/06%20-%20We%20split%2
 * Nest all tests for a component in a describe block named after the component, followed by a describe block for the feature. This allows the results to be grouped together by the test runner.
 
   ```ts
-  // seo.test.tsx
-  describe('<ProductIndex />', () => {
+  // ProductDetails-seo.test.tsx
+  describe('<ProductDetails />', () => {
     describe('seo', () => {
       // tests
     });
   });
 
-  // images.test.tsx
-  describe('<ProductIndex />', () => {
+  // ProductDetails-images.test.tsx
+  describe('<ProductDetails />', () => {
     describe('images', () => {
       // tests
     });

--- a/Best practices/React/Testing.md
+++ b/Best practices/React/Testing.md
@@ -187,7 +187,7 @@ Another benefit of testing React components is that they typically abstract away
 
 As noted in the [decision record](../../Decision%20records/06%20-%20We%20split%20up%20large%20component%20test%20files%20by%20feature.md), when a component’s test file gets large enough that is hard to navigate and/ or stresses editor tooling, we split the test file by feature. Below are some best practices for naming and structure of these split files:
 
-* Name the split files in the format `component-feature.test.tsx`. For example, a test file for the SEO feature of a `ProductDetails` component would be found at `ProductDetails/tests/seo.test.tsx`.
+* Name the split files in the format `Component-feature.test.tsx`. For example, a test file for the SEO feature of a `ProductDetails` component would be found at `ProductDetails/tests/ProductDetails-seo.test.tsx`.
 * Tests that do not directly relate to a particular feature, or are too small to warrant a separate test file, should remain in a test file named after the component (for example, `ProductDetails/tests/ProductDetails.test.tsx`).
 * Nest all tests for a component in a describe block named after the component, followed by a describe block for the feature. This allows the results to be grouped together by the test runner.
 

--- a/Decision records/05 - We use Details and List to describe index- and show-style route components.md
+++ b/Decision records/05 - We use Details and List to describe index- and show-style route components.md
@@ -1,4 +1,4 @@
-# We use `Details` and `List` to describe index- and show-style route components
+# We use `List` and `Details` to describe index- and show-style route components
 
 ## Date
 
@@ -23,7 +23,7 @@ In Shopify Web, we initially named our "route" components after their Rails equi
 
 Eventually, there was so much duplication between `ProductShow` and `ProductCreate` that the two were merged into a single component, still named `ProductShow`.
 
-This same naming convention was copied to many other sections and apps that had similar CRUD-based resources.
+This same naming convention was copied to many other sections and apps that had similar [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete)-based resources.
 
 ## Decision
 
@@ -41,3 +41,5 @@ We considered the following alternative naming for the list/ detail pages:
 * `Resources` and `Resource`: same as the above, but with the added issue of overly similar names
 
 We feel that `ResourceList` and `ResourceDetails` provides the best balance as default naming. The names are sufficiently unique and descriptive, and align closely with how platforms like iOS refer to similar concepts ("master/ detail"). `ResourceList` does feel overly prescriptive on how the page should look, rather than its purpose, but we could not come up with better alternatives.
+
+Note that this decision only applies to resource-based pages organized in traditional CRUD-style URLs. Other pages should use names that represent their purpose, not attempt to fit them within this `Details`/ `List` naming convention. For example, the main index page for the admin would be named `Home`, not `HomeIndex` or `HomeDetails`.

--- a/Decision records/05 - We use Details and List to describe index- and show-style route components.md
+++ b/Decision records/05 - We use Details and List to describe index- and show-style route components.md
@@ -1,0 +1,43 @@
+# We use `Details` and `List` to describe index- and show-style route components
+
+## Date
+
+July 30, 2018
+
+## Contributors
+
+* Chris Sauvé
+* Mallory Allen
+* Tzvi Melamed
+* Ismail Syed
+* Gord Pearson
+* Matt Seccafien
+
+## Summary
+
+Many apps will have components that represent discrete routes in the application. These routes often represent traditional CRUD-style operations on a resource. In these cases, we use the terms "Details" (for a single resource) and "List" (for a list of resources) to name these routes.
+
+## History
+
+In Shopify Web, we initially named our "route" components after their Rails equivalents. For a resource like products, we had a `ProductIndex` component (for `/admin/products`), `ProductShow` (for `/admin/products/:id`), and `ProductCreate` (for `/admin/products/new`). These matched up the default naming style for Rails actions. 
+
+Eventually, there was so much duplication between `ProductShow` and `ProductCreate` that the two were merged into a single component, still named `ProductShow`.
+
+This same naming convention was copied to many other sections and apps that had similar CRUD-based resources.
+
+## Decision
+
+The `Show`/ `Create`/ `Index` postfix naming has one major benefit: it matches the Rails convention. This makes it simpler for Rails-knowledgeable developers to apply their existing mental model to the React application, and makes a conversion from a Rails codebase to a React one even simpler.
+
+However, there are numerous issues with this approach:
+
+* It does not necessarily line up with the way the page interacts with the GraphQL API (there is no CRUD in GraphQL)
+* It feels restrictive in a world outside of Rails, where there is no built-in assumptions about the structure of routes around a resource
+* It does not do a good job of indicating the responsibility of a merged show/ create component
+
+We considered the following alternative naming for the list/ detail pages:
+
+* `ResourceList` and `Resource`: `Resource` is overly generic and can easily conflict with other identifiers
+* `Resources` and `Resource`: same as the above, but with the added issue of overly similar names
+
+We feel that `ResourceList` and `ResourceDetails` provides the best balance as default naming. The names are sufficiently unique and descriptive, and align closely with how platforms like iOS refer to similar concepts ("master/ detail"). `ResourceList` does feel overly prescriptive on how the page should look, rather than its purpose, but we could not come up with better alternatives.

--- a/Decision records/06 - We split up large component test files by feature.md
+++ b/Decision records/06 - We split up large component test files by feature.md
@@ -25,7 +25,7 @@ At the time of this decision, the largest of these components had test files any
 
 ## Decision
 
-Developer experience is a higher priority than technical purity, so we have decided these test files need to be split. Our existing directory structure can handle this fairly gracefully; a `Component/tests` directory already contains a single test file for the component (alongside directories for things like fixtures), so collocating all of the split test files in this directory is the natural next step.
+Developer experience is a higher priority than technical purity, so we have decided these test files need to be split; the velocity improvement for our formatting tools along is worth a more complex file setup. Our existing directory structure can handle this fairly gracefully; a `Component/tests` directory already contains a single test file for the component (alongside directories for things like fixtures), so collocating all of the split test files in this directory is the natural next step.
 
 There are different options for how we could split these files, though. We considered two main alternatives:
 

--- a/Decision records/06 - We split up large component test files by feature.md
+++ b/Decision records/06 - We split up large component test files by feature.md
@@ -1,0 +1,41 @@
+# We split up large component test files by feature
+
+## Date
+
+July 30, 2018
+
+## Contributors
+
+* Chris Sauvé
+* Mallory Allen
+* Tzvi Melamed
+* Ismail Syed
+* Gord Pearson
+* Matt Seccafien
+
+## Summary
+
+When a test file for a component grows too large, it should split into several sibling test files, each covering a feature of the larger component.
+
+## History
+
+In Shopify Web, some of our components have grown extremely large, despite good separation of discrete logical areas into separate subcomponents. These components are usually those that represent a "page", and are often needed because of the need to collocate form data and/ or GraphQL handling.
+
+At the time of this decision, the largest of these components had test files anywhere from 3000–4500 lines long. Based on the complexity of other pages in the admin, we anticipate these not to be the largest test files in the app. The size of these files causes tooling like VSCode’s auto-formatting/ linting highlights not to function correctly, make navigating the file very difficult, and usually require a developer to focus a part of the test file to work on tests iteratively.
+
+## Decision
+
+Developer experience is a higher priority than technical purity, so we have decided these test files need to be split. Our existing directory structure can handle this fairly gracefully; a `Component/tests` directory already contains a single test file for the component (alongside directories for things like fixtures), so collocating all of the split test files in this directory is the natural next step.
+
+There are different options for how we could split these files, though. We considered two main alternatives:
+
+* By the "setup state" of the component. For example, all tests that cover the "empty state" case of the component under test would be grouped together.
+* By feature. For example, all tests relating to SEO on a product would be grouped together.
+
+Grouping the tests be their initial state makes it simpler to get the component under test in the right starting state, as every test in a given file will have nearly identical setup steps. This reduces the overhead of finding ways to share the utilities needed to get a component into this state across test files. However, it splits up tests for a feature across multiple test files, as you would need to check how the parts of a feature respond to the different states the component can start in.
+
+Grouping the tests by feature essentially takes the inverse approach; all tests covering a feature are collocated together, at the cost of having many different initial states for those tests. It may also not always scale well, when most of the complexity of a component is in service of a single feature. However, we believe this form of test splitting is preferable because it does match well to how a component itself is broken down; a feature is often largely handled by a subcomponent, so this split also allows us to collocate most tests related to the subcomponent in charge of that UI (this maps nicely to the way we have currently nested `describe` blocks for components). This splitting also gives us a more natural place to store tests that do not really have an "initial state", such as functionality that runs on mount independent of the state of the component.
+
+Note that "feature", as it used above, should be considered as a rough proxy for a user flow. "Saving" is not a feature, but is instead a test that needs to be added for every feature (for example, `it can save the new SEO title of a product` would be a test of the `seo` feature of a product page component).
+
+With the above in mind, we have decided that tests should be organized by feature. Note that this decision applies only to a component where the test file has grown to the size where it feels the pains described earlier in this document (based on current tools and computation power, we believe this is happens to test files somewhere between 500–1000 lines).


### PR DESCRIPTION
This PR adds docs for the two decisions the Web Foundation team discussed on July 30:

* We name our route-level components `ResourceList` and `ResourceDetails`, instead of `ResourceIndex` and `ResourceShow` as we currently do in Web.
* We split test files by feature when component test files get too long.