### PR TITLE
Add basic hook docs

### DIFF
--- a/Best practices/Enzyme.md
+++ b/Best practices/Enzyme.md
@@ -1,5 +1,7 @@
 # Enzyme
 
+> **Note**: We now recommend using [`@shopify/react-testing`](https://github.com/Shopify/quilt/tree/master/packages/react-testing) to test React components, as it avoids many pitfalls of Enzyme and has better support for hooks, triggering props, and more.
+
 [Enzyme](http://airbnb.io/enzyme/) is a library that makes it easy to traverse and manipulate the output of React components. We recommend it for all React applications complex enough to warrant tests, as the readability it provides outweighs the additional API surface area to learn.
 
 ## Table of contents

--- a/Best practices/React/API design.md
+++ b/Best practices/React/API design.md
@@ -1,0 +1,35 @@
+# React API design
+
+## Components
+
+TODO
+
+## Hooks
+
+When building custom hooks, make sure to use the built-in hooks React provides as a guide. These hooks will be the most familiar to developers, and will make composing them in to your custom hook much easier. In particular, follow these rules of thumb:
+
+* Where possible, return two or fewer values from a hook, and return them in a tuple, like `React.useState` (if you have no choice but to return more than three values, return them as a single object instead)
+
+* If your hook runs any kind of function in a `React.useEffect` block, you should accept an array of inputs as the second argument to the hook, like `React.useEffect`. These can be merged with any inputs that your function depends on. Similarly, you should preserve the ability of the custom hook to return a cleanup function:
+
+  ```tsx
+  function useEffectWithMyContext(
+    effect: (object: MyObject) => void | (() => void),
+    inputs: unknown[] = [],
+  ) {
+    const myObject = React.useContext(MyContext);
+
+    React.useEffect(() => {
+      const cleanup = effect(myObject);
+      return () => {
+        myObject.cleanup();
+
+        if (cleanup) {
+          cleanup();
+        }
+      };
+    }, [myObject, ...inputs]);
+  }
+  ```
+
+* If your component requires that the user pass an argument that can be expensive to construct, allow them to pass a "lazy" version (a function that returns the object) instead, like `React.useState`.

--- a/Best practices/React/Organization.md
+++ b/Best practices/React/Organization.md
@@ -12,14 +12,24 @@ TODO
 
 ### `/app/hooks` and `<Component>/hooks`
 
-[React Hooks](https://reactjs.org/docs/hooks-overview.html) provide an alternative form of composition that can be extremely useful for sharing logic in an application. Because of this important role, hooks should generally be given their own top-level directory; anywhere you might have a `components` directory for nested components, you can also place a `hooks` directory for nested hooks (including at the root of the project). Like `components`, you should import directly from the `hooks` directory, rather than the nested directories:
+> **Note:** because hooks are so new, we haven’t been able to test these recommendations as much as we have for other parts of project structure. If you are trying to figure out where a hook should go, you should come discuss it with us in the `#web-foundation-tech` slack channel.
+
+[React Hooks](https://reactjs.org/docs/hooks-overview.html) provide an alternative form of composition that can be extremely useful for sharing logic in an application. Because of this important role, hooks should generally be given their own top-level directory; anywhere you might have a `components` directory for nested components, you can also place a `hooks` directory for nested hooks (including at the root of the project). You should import from the subdirectory of `hooks`, like you would for `utilities`:
 
 ```tsx
 // bad
-import {useProductForm} from './hooks/form';
+import {useProductForm} from './hooks';
 
 // good
-import {useProductForm} from './hooks';
+import {useProductForm} from './hooks/form';
+```
+
+We recommend having a dedicated subdirectory for each hook "type", rather than having individual files. This makes it easy to introduce a test directory if your hook requires tests. File and directory names should be in kebab case to clearly differentiate them from components. Also unlike components, we recommend using named exports, as you are more likely to export multiple hooks for a particular "theme" than you are for components.
+
+```
+/app/hooks/form/index.ts
+/app/hooks/form/form.ts
+/app/hooks/form/tests/form.test.ts
 ```
 
 The example above works very well for hook-only situations, but does not work well when you also need to export context or other components alongside the hook. In cases like this, we prefer collocation of the files along the "theme" of the files, not based on the values exported from them (an application of [isolation over integration](https://github.com/Shopify/web-foundation/blob/master/Principles/4%20-%20Isolation%20over%20integration.md)). If you have code like this, follow the [context-based library organization](#context-based-library), but placed in a nested `utilities` directory:

--- a/Best practices/React/Organization.md
+++ b/Best practices/React/Organization.md
@@ -12,7 +12,7 @@ TODO
 
 ### `/app/hooks` and `<Component>/hooks`
 
-Hooks provide an alternative form of composition that can be extremely useful for sharing logic in an application. Because of this important role, hooks should generally be given their own top-level directory; anywhere you might have a `components` directory for nested components, you can also place a `hooks` directory for nested hooks (including at the root of the project). Like `components`, you should import directly from the `hooks` directory, rather than the nested directories:
+[React Hooks](https://reactjs.org/docs/hooks-overview.html) provide an alternative form of composition that can be extremely useful for sharing logic in an application. Because of this important role, hooks should generally be given their own top-level directory; anywhere you might have a `components` directory for nested components, you can also place a `hooks` directory for nested hooks (including at the root of the project). Like `components`, you should import directly from the `hooks` directory, rather than the nested directories:
 
 ```tsx
 // bad

--- a/Best practices/React/Performance.md
+++ b/Best practices/React/Performance.md
@@ -5,6 +5,7 @@
 1. [Complementary packages](#complementary-packages)
 1. [Server rendering](#server-rendering)
 1. [Asynchronous component loading](#asynchronous-component-loading)
+1. [Memoization](#memoization)
 
 ## Complementary packages
 
@@ -12,6 +13,8 @@
 * [`@shopify/react-graphql`](https://github.com/Shopify/quilt/tree/master/packages/react-graphql): provides a functions to create asynchronous GraphQL query components with built-in prefetching
 * [`@shopify/react-import-remote`](https://github.com/Shopify/quilt/tree/master/packages/react-import-remote): provides a React component for performance-conscious loading of external scripts
 * [`@shopify/react-html`](https://github.com/Shopify/quilt/tree/master/packages/react-html): provides a `<Preconnect />` component for warming up connections to other domains, and a collection of tools for easily serializing data for server-rendered pages
+* [`@shopify/function-enhancers`](https://github.com/Shopify/quilt/tree/master/packages/function-enhancers): provides a set of helpers that run on functions, including helpers for memoizing and debouncing
+* [`@shopify/decorators`](https://github.com/Shopify/quilt/tree/master/packages/decorators): provides commonly-needed decorators for methods
 
 ## Server rendering
 
@@ -110,3 +113,12 @@ const MyComponent = createAsyncComponent({
 What gets rendered by each of these components can be customized using the `renderPrefetch`, `renderPreload`, and `renderKeepFresh` [options](https://github.com/Shopify/quilt/tree/master/packages/react-async#createasynccomponent). You can use this customization to preload additional asynchronous components that yours depends on.
 
 At a minimum, we recommend rendering the `<Prefetch />` for any asynchronous components that are rendered by a route your component links to. This pattern can be generalized using the [`<PrefetchRoute />` component](https://github.com/Shopify/quilt/tree/master/packages/react-async#prefetchroute-and-prefetcher) in `@shopify/react-async`.
+
+## Memoization
+
+Memoization is the process of storing previously-computed results to speed up subsequent operations. There are two common places we memoize in a React application:
+
+* Methods or other functions that need to generate results for lists of data (we recommend using [`@shopify/decorators`](https://github.com/Shopify/quilt/tree/master/packages/decorators#memoize) and [`@shopify/function-enhancers`](https://github.com/Shopify/quilt/tree/master/packages/function-enhancers#memoize))
+* Using the `React.useMemo`/ `React.useCallback` hooks to preserve objects across renders of a function component
+
+In all cases, make sure to **Measure, update, then measure again**. It is easy to fall into the trap of prematurely optimizing React components without taking stock of the actual results of those changes. Memoization (and the related concepts of `React.memo`/ `React.PureComponent`/ `shouldComponentUpdate`) should only be used in hot paths where un-memoized results lead to excessive re-rendering of expensive components.

--- a/Best practices/React/Testing.md
+++ b/Best practices/React/Testing.md
@@ -89,6 +89,8 @@ There are many parts of React components that should not be tested as they are i
 
 * `state`. State is not directly manipulable from other components, and so should be treated as private. In order to simulate setting state, trigger the props of components rendered by your component with arguments that result in the component getting into that state. Once a component is in a state, do not assert on the state having a particular shape; instead, assert that the subcomponents being rendered have the expected props.
 
+* What hooks were used in a component. The hooks you use generally end up doing one of three things: pull in context, store local state, or create side effects. How context is pulled in to a component is an implementation detail; `useContext`, `contextType`, and `Context.Consumer` are all acceptable and interchangeable. As noted above, local state is never tested. Finally, we should test that the side effects themselves happened, not how they were triggered.
+
 * Instances for class components. All methods should be private on your React components, as you will otherwise be encouraging users to break out of the declarative model of React. This includes React’s lifecycle methods, which are implementation details of the framework itself. Never call any of these methods directly. Similarly, function components should never use the `useImperativeHandle` hook to provide a public API.
 
 * `className`s. Classes have no meaning outside of visual tests; the presence of a class does not provide any real confidence over the correctness of the rendered UI. `style` props of subcomponents may be tested if they rely on internal computations involving `state` or `props`.

--- a/Best practices/React/Testing.md
+++ b/Best practices/React/Testing.md
@@ -1,15 +1,20 @@
 # React Testing
 
-In addition to the guide below, you should read through our [Enzyme](../Enzyme.md) and [Jest](../Jest.md) best practices. These two tools are strongly recommended for testing a React application.
+In addition to the guide below, you should read through our [Jest](../Jest.md) best practices. These two tools are strongly recommended for testing a React application. While we now recommend [`@shopify/react-testing`](https://github.com/Shopify/quilt/tree/master/packages/react-testing) for mounting and testing React components, we also have recommendations for projects using [Enzyme](../Enzyme.md).
+
+## Table of contents
 
 1. [Complementary packages](#complementary-packages)
 1. [Strategy](#strategy)
-1. [Best practices](#best-practices)
+1. [Hooks](#hooks)
+1. [Split test files](#split-test-files)
+1. [Style and naming](#style-and-naming)
 
 ## Complementary packages
 
+* [`@shopify/react-testing`](https://github.com/Shopify/quilt/tree/master/packages/react-testing): utilities for testing React components as detailed in this guide
+* [`@shopify/graphql-testing`](https://github.com/Shopify/quilt/tree/master/packages/graphql-testing): test infrastructure for simulating GraphQL queries, which includes a mock Apollo client for your tests
 * [`@shopify/jest-dom-mocks`](https://github.com/Shopify/quilt/tree/master/packages/jest-dom-mocks): mock versions of browser globals including clock, timers, animation frames, and more
-* [`@shopify/enzyme-utilities`](https://github.com/Shopify/quilt/tree/master/packages/enzyme-utilities): Utility functions for interacting with [Enzyme](https://github.com/airbnb/enzyme)
 * [`@shopify/jest-mock-router`](https://github.com/Shopify/quilt/tree/master/packages/jest-mock-router): a mock version of the React Router 3.x router
 
 ## Strategy
@@ -23,13 +28,13 @@ Tests for props will usually fall into one of a few categories:
   * **Callbacks:** test that the callback was called in response to the relevant action, and that it was called with the appropriate arguments. This is usually done by simulating a call on a subcomponent (for example, simulating a click on a contained `button`, which eventually leads to the callback being called). Tests should pass in a spy function for the prop under test to verify the calls.
 
     ```js
-    // Example using Jest and Enzyme:
+    // Example using Jest and @shopify/react-testing:
 
     describe('onAction()', () => {
       it('is called when the child component is clicked', () => {
         const spy = jest.fn();
         const myComponent = mount(<MyComponent onAction={spy} />);
-        trigger(myComponent.find(ChildComponent), 'onClick');
+        myComponent.find(ChildComponent)!.trigger('onClick');
         expect(spy).toHaveBeenCalled();
       });
     });
@@ -38,12 +43,12 @@ Tests for props will usually fall into one of a few categories:
   * **Rendering logic:** test that some set of components are rendered as a result of the prop value passed in.
 
     ```js
-    // Example using Jest and Enzyme:
+    // Example using Jest and @shopify/react-testing:
 
     describe('products', () => {
       it('renders an empty state when the list is empty', () => {
         const productList = mount(<ProductList products={[]} />);
-        expect(productList.find(EmptyState)).toExist();
+        expect(productList).toContainReactComponent(EmptyState);
       });
     });
     ```
@@ -51,13 +56,13 @@ Tests for props will usually fall into one of a few categories:
   * **Content:** test that a particular prop is rendered within the component (as discussed below, avoid attempts to test that children markup is rendered with any particular styles).
 
     ```js
-    // Example using Jest and Enzyme:
+    // Example using Jest and @shopify/react-testing:
 
     describe('children', () => {
       it('renders within a card', () => {
         const children = <div>Test</div>;
         const myComponent = mount(<MyComponent>{children}</MyComponent>);
-        expect(myComponent.find(Card)).toContainReact(children);
+        expect(myComponent.find(Card)).toContainReactText('Test');
       });
     });
     ```
@@ -65,13 +70,13 @@ Tests for props will usually fall into one of a few categories:
 * **Subcomponents rendered to manage the behaviour of your component**. You will sometimes render components entirely to manage internal state. This is very common in "controller" components — these will have very few props, but may render components that manage internal state. For example, a component might render a button that toggles some other part of the UI to be visible. In these cases, group the tests under `describe`s named after the subcomponent name (i.e., `describe('<ChildComponent />')`).
 
   ```js
-  // Example using Jest and Enzyme:
+  // Example using Jest and @shopify/react-testing:
 
   describe('<MyModal />', () => {
     it('is rendered open when the update action is triggered', () => {
       const myComponent = mount(<MyComponent />);
       triggerUpdateAction(myComponent);
-      expect(myComponent.find(MyModal)).toHaveProp('open', true);
+      expect(myComponent.find(MyModal)).toHaveReactProps({open: true});
     });
   });
   ```
@@ -84,7 +89,7 @@ There are many parts of React components that should not be tested as they are i
 
 * `state`. State is not directly manipulable from other components, and so should be treated as private. In order to simulate setting state, trigger the props of components rendered by your component with arguments that result in the component getting into that state. Once a component is in a state, do not assert on the state having a particular shape; instead, assert that the subcomponents being rendered have the expected props.
 
-* Instances for class components. All methods should be private on your React components, as you will otherwise be encouraging users to break out of the declarative model of React. This includes React’s lifecycle methods, which are implementation details of the framework itself. Never call any of these methods directly.
+* Instances for class components (or of function components, through `React.useImperativeHandle`). All methods should be private on your React components, as you will otherwise be encouraging users to break out of the declarative model of React. This includes React’s lifecycle methods, which are implementation details of the framework itself. Never call any of these methods directly.
 
 * `className`s. Classes have no meaning outside of visual tests; the presence of a class does not provide any real confidence over the correctness of the rendered UI. `style` props of subcomponents may be tested if they rely on internal computations involving `state` or `props`.
 
@@ -96,7 +101,85 @@ Another benefit of testing React components is that they typically abstract away
 
 [Jest](https://facebook.github.io/jest/), our recommended test runner, internally uses [JSDom](https://github.com/jsdom/jsdom), which creates an all-JavaScript version of the DOM for the purpose of these tests. If you find that something is missing from JSDom, (for example, a browser global that does not behave as expected in the test environment), consider mocking out that global. Note that anything related to style calculation will not work correctly; this is a feature, not a bug. Your unit tests should not attempt to test style-related concerns directly, as these are typically better handled with visual regression tests, integration tests, or manual verification.
 
-## Best practices
+## Hooks
+
+React hooks present an interesting testing challenge. They are not quite React components, but they are attached to the React lifecycle because of their reliance on primitive hooks like `useEffect`. However, whether a component uses hooks or not (and, in fact, whether it is a class or function component) is strictly an implementation detail, which we [don’t test](#test-the-interface-not-the-implementation).
+
+You should test hooks by testing that they have the expected effect on a component that uses them. This is commonly done with a "dummy" component written exclusively for tests that calls the hook and returns no actual markup. Once you have a simple component to act as a test harness, ask yourself what feature your hook actually provides, and then have your test component accept props that will allow you to test that feature.
+
+As an example, consider a `useEventListener` hook that attaches an event listener to window, calls one of the hook arguments when that event listener is triggered, and removes the event listener on unmount. The feature this hook provides is that it calls a function when a particular event is dispatched, contingent on the component still being mounted. In order to test this, our test component must accept a spy function that we can track during the test, and the event to listen for. The resulting test component might look like this:
+
+```tsx
+// Our hook.
+function useEventListener(event: string, listener: () => void) {}
+
+// Our test component. We recommend keeping this function at the top
+// of the file, near the imports, so that the tests read a bit more
+// linearly.
+function EventListenerUser({event, listener}: {event: string; listener: () => void}) {
+  useEventListener(listener);
+  return null;
+}
+```
+
+During tests, we would follow the same process outlined in the rest of this document: we’ll mount the component, get it in a particular state, and assert that the effects we expect have happened:
+
+```tsx
+// These tests are **not** exhaustive: we are missing tests for non-matching
+// events, events on other nodes, etc.
+
+it('calls the listener when a matching event is dispatched', () => {
+  const spy = jest.fn();
+  const eventName = 'my-event';
+  mount(<EventListenerUser event={eventName} listener={spy} />);
+
+  const event = new CustomEvent(eventName);
+  window.dispatchEvent(event);
+  
+  expect(spy).toHaveBeenCalled();
+});
+
+it('does not call the listener when the component has unmounted', () => {
+  const spy = jest.fn();
+  const eventName = 'my-event';
+  const eventListenerUser = mount(<EventListenerUser event={eventName} listener={spy} />);
+
+  eventListenerUser.unmount();
+
+  const event = new CustomEvent(eventName);
+  window.dispatchEvent(event);
+
+  expect(spy).not.toHaveBeenCalled();
+});
+```
+
+If you are testing a library that exports a hook and a component that uses the hook and returns nothing (like our `EventListenerUser` component above), you only need to test one. We recommend testing the component version only; otherwise, it can be confusing why you have a component for tests that so closely mirrors a component that is actually exported from the library.
+
+## Split test files
+
+As noted in the [decision record](../../Decision%20records/06%20-%20We%20split%20up%20large%20component%20test%20files%20by%20feature.md), when a component’s test file gets large enough that is hard to navigate and/ or stresses editor tooling, we split the test file by feature. Below are some best practices for naming and structure of these split files:
+
+* Name the split files in the format `Component-feature.test.tsx`. For example, a test file for the SEO feature of a `ProductDetails` component would be found at `ProductDetails/tests/ProductDetails-seo.test.tsx`.
+* Tests that do not directly relate to a particular feature, or are too small to warrant a separate test file, should remain in a test file named after the component (for example, `ProductDetails/tests/ProductDetails.test.tsx`).
+* Nest all tests for a component in a describe block named after the component, followed by a describe block for the feature. This allows the results to be grouped together by the test runner.
+
+  ```ts
+  // ProductDetails-seo.test.tsx
+  describe('<ProductDetails />', () => {
+    describe('seo', () => {
+      // tests
+    });
+  });
+
+  // ProductDetails-images.test.tsx
+  describe('<ProductDetails />', () => {
+    describe('images', () => {
+      // tests
+    });
+  });
+  ```
+
+## Style and naming
 
 * The top-level describe block of a React component should be a self-closing JSX tag of the component’s name. You should use the same format for nested describe blocks meant to test the rendering of particular subcomponents.
 
@@ -194,7 +277,7 @@ Another benefit of testing React components is that they typically abstract away
   });
   ```
 
-* If you find that you need to share utilities between test files (for example, because you have split a single component’s tests among several files), put them in the nearest shared `tests/utilities` directory. This differentiated test files from "support" files, and mirrors how we store fixtures.
+* If you find that you need to share utilities between test files (for example, because you have split a single component’s tests among several files), put them in the nearest shared `tests/utilities` file or directory. This differentiated test files from "support" files, and mirrors how we store fixtures.
 
   ```
   # Bad
@@ -202,37 +285,20 @@ Another benefit of testing React components is that they typically abstract away
   └── tests
       ├── feature-one.test.tsx
       ├── feature-two.test.tsx
-      └── utilities.ts
+      └── non-test-file.ts
 
   # Good
   MyComponent/
   └── tests
       ├── feature-one.test.tsx
       ├── feature-two.test.tsx
+      └── utilities.ts
+
+  # Also good
+  MyComponent/
+  └── tests
+      ├── feature-one.test.tsx
+      ├── feature-two.test.tsx
       └── utilities/
           └── index.ts
-  ```
-
-### Split test files
-
-As noted in the [decision record](../../Decision%20records/06%20-%20We%20split%20up%20large%20component%20test%20files%20by%20feature.md), when a component’s test file gets large enough that is hard to navigate and/ or stresses editor tooling, we split the test file by feature. Below are some best practices for naming and structure of these split files:
-
-* Name the split files in the format `Component-feature.test.tsx`. For example, a test file for the SEO feature of a `ProductDetails` component would be found at `ProductDetails/tests/ProductDetails-seo.test.tsx`.
-* Tests that do not directly relate to a particular feature, or are too small to warrant a separate test file, should remain in a test file named after the component (for example, `ProductDetails/tests/ProductDetails.test.tsx`).
-* Nest all tests for a component in a describe block named after the component, followed by a describe block for the feature. This allows the results to be grouped together by the test runner.
-
-  ```ts
-  // ProductDetails-seo.test.tsx
-  describe('<ProductDetails />', () => {
-    describe('seo', () => {
-      // tests
-    });
-  });
-
-  // ProductDetails-images.test.tsx
-  describe('<ProductDetails />', () => {
-    describe('images', () => {
-      // tests
-    });
-  });
   ```

--- a/Best practices/React/Testing.md
+++ b/Best practices/React/Testing.md
@@ -89,7 +89,7 @@ There are many parts of React components that should not be tested as they are i
 
 * `state`. State is not directly manipulable from other components, and so should be treated as private. In order to simulate setting state, trigger the props of components rendered by your component with arguments that result in the component getting into that state. Once a component is in a state, do not assert on the state having a particular shape; instead, assert that the subcomponents being rendered have the expected props.
 
-* Instances for class components (or of function components, through `React.useImperativeHandle`). All methods should be private on your React components, as you will otherwise be encouraging users to break out of the declarative model of React. This includes React’s lifecycle methods, which are implementation details of the framework itself. Never call any of these methods directly.
+* Instances for class components. All methods should be private on your React components, as you will otherwise be encouraging users to break out of the declarative model of React. This includes React’s lifecycle methods, which are implementation details of the framework itself. Never call any of these methods directly. Similarly, function components should never use the `useImperativeHandle` hook to provide a public API.
 
 * `className`s. Classes have no meaning outside of visual tests; the presence of a class does not provide any real confidence over the correctness of the rendered UI. `style` props of subcomponents may be tested if they rely on internal computations involving `state` or `props`.
 


### PR DESCRIPTION
Fixes https://github.com/Shopify/web-foundation/issues/75
Fixes https://github.com/Shopify/web-foundation/issues/74
Fixes https://github.com/Shopify/web-foundation/issues/76

This PR adds a bunch of docs to support hook stuff:

1. Update testing guide to point at new hook-friendly libraries
1. Add API design doc that gives some design guidelines for hooks
1. Document the shape of an `app/hooks` directory for basic hook composition
1. Document the general shape of a library that has hook + context + other stuff
1. Document preference for testing components using the hook rather than the hook directly

The only one I am still waffling on is the `app/hooks`/ `MyComponent/hooks` thing. Conceptually I like the hooks being there, because hooks can be equally important to components (which we have `app/components`/ `MyComponent/components` for), but I worry that there will be a lot of reaching between `utilities` and `hooks` directories.