### PR TITLE
Add component folder guidelines

### DIFF
--- a/handbook/Best practices/React/Organization.md
+++ b/handbook/Best practices/React/Organization.md
@@ -29,16 +29,28 @@ If you foresee this component growing quickly in complexity or needing a subcomp
 
 #### 2. Isolate your component to a folder (of the same name) as the component grows
 
-When you move your component into it's own folder, you
-
 ```
 ├── component.js
 └── components
-    └── MyComponent.js
+    └── MyComponent
         ├── MyComponent.js
         ├── MyComponent.scss
         └── MyComponent.test.js
 ```
+
+When you move your component into it's own folder, you will need to figure out how to maintain all existing import paths.
+
+```
+import {MyComponent} from './components/MyComponent';
+// would need to become 👇
+import {MyComponent} from './components/MyComponent/MyComponent';
+```
+
+You have several options to fix this problem:
+
+1. rename the component's filename from `MyComponent.js` to `index.js` to
+2. create an `index.js` inside the component's folder that exports `MyComponent.js`
+3. create a `components.js` file next to the component's folder that exports each component in the `components/` folder.
 
 #### 3. As your component grows, group like-files in folders.
 

--- a/handbook/Best practices/React/Organization.md
+++ b/handbook/Best practices/React/Organization.md
@@ -5,8 +5,10 @@
 This section describes a sensible starting point for organizing a React application that supports server-side rendering.
 
 ## Application
+> `/app`
 
 ### React Components (and sub-components)
+> `/app/components` and `<Component>/components`
 
 React Components should always exist in a `components/` folder, but the component's internal structure may change depending on their complexity.
 

--- a/handbook/Best practices/React/Organization.md
+++ b/handbook/Best practices/React/Organization.md
@@ -6,7 +6,7 @@ This section describes a sensible starting point for organizing a React applicat
 
 ## Application
 
-### React Components and Sub-Components
+### React Components and Sub-components
 
 React Components should always exist in a `components/` folder, but the component's internal structure may change depending on their complexity.
 
@@ -56,9 +56,9 @@ You have several options to fix this problem:
 
 Common types to group inside a component:
 - Multiple tests into `./tests/`
-- graphQL queries and mutations in `./graphql/`
-- Subcomponents of the component in it's own `./components/` subfolder
-- utility files containing helpers in `./utils/`
+- GraphQL queries and mutations in `./graphql/`
+- Sub-components of the component in it's own `./components/` subfolder
+- Utility files containing helpers in `./utilities/`
 
 A more complex component could start to look like either of these examples. As always, choose the grouping or abstraction that makes sense to you.
 

--- a/handbook/Best practices/React/Organization.md
+++ b/handbook/Best practices/React/Organization.md
@@ -56,9 +56,11 @@ You have several options to fix this problem:
 
 Common types to group inside a component:
 - Multiple tests into `./tests/`
-- GraphQL queries and mutations in `./graphql/`
-- Sub-components of the component in it's own `./components/` subfolder
+- GraphQL queries and mutations in `./graphql/` (if there are still too many feel free to group those as well)
 - Utility files containing helpers in `./utilities/`
+- Sub-components of the component in it's own `./components/` subfolder
+- Hooks used in the component go to `./hooks/`
+- And so on...
 
 A more complex component could start to look like either of these examples. As always, choose the grouping or abstraction that makes sense to you.
 

--- a/handbook/Best practices/React/Organization.md
+++ b/handbook/Best practices/React/Organization.md
@@ -6,107 +6,58 @@ This section describes a sensible starting point for organizing a React applicat
 
 ## Application
 
-### React Components and Sub-components
+### React Components (and sub-components)
 
 React Components should always exist in a `components/` folder, but the component's internal structure may change depending on their complexity.
 
-
 #### 1. Start with a file and a test
 
-At its simplest a component will exist as a component and a test at the `components/` level.
-
-If you foresee this component growing quickly in complexity or needing a subcomponent, feel free to jump straight to #2.
-```
-.
-└── components
-    ├── ...
-    ├── MyComponent.tsx
-    └── tests
-        ├── ...
-        └── MyComponent.test.tsx
-```
-
-
-#### 2. Isolate your component to a folder (of the same name) as the component grows
+For a new component, start with a PascalCased folder to contain all the files and create an `index.ts` file for the components exports, the component file and it's test.
 
 ```
-├── component.tsx
-└── components
-    └── MyComponent
-        ├── MyComponent.tsx
-        ├── MyComponent.scss
-        └── MyComponent.test.tsx
+MyComponent/
+├── index.ts
+├── MyComponent.tsx
+└── MyComponent.test.tsx
 ```
 
-When you move your component into it's own folder, you will need to figure out how to maintain all existing import paths.
+#### 2. Group related component files in folders
+
+As your component increases in complexity, it will start to have many dependencies. You'll create subcomponents, hooks, as well as multiple tests for all those extra dependencies. This is when we start to add folders to organize the complexity (and not before).
 
 ```
-import {MyComponent} from './components/MyComponent';
-// would need to become 👇
-import {MyComponent} from './components/MyComponent/MyComponent';
+MyComponent/
+├── index.ts
+├── MyComponent.tsx
+├── tests <--------------------------------- More than one test? Add a `tests/` folder!
+│   ├── MyComponent-layout.test.tsx
+│   └── MyComponent-uploader.test.tsx
+├── components <---------------------------- More than one subcomponent? Add a `components/` folder!
+│   ├── SubComponent.tsx
+│   └── OtherSubComponent.tsx
+└── index.ts
 ```
 
-You have several options to fix this problem:
+#### 3. If subcomponents get complex, continue the pattern
 
-1. rename the component's filename from `MyComponent.tsx` to `index.tsx` to
-2. create an `index.tsx` inside the component's folder that exports `MyComponent.tsx`
-3. create a `components.tsx` file next to the component's folder that exports each component in the `components/` folder.
+If one of your dependencies grows in size/complexity, continue applying steps 1-3 as needed.
 
-#### 3. As your component grows, group like-files in folders.
-
-Common types to group inside a component:
-- Multiple tests into `./tests/`
-- GraphQL queries and mutations in `./graphql/` (if there are still too many feel free to group those as well)
-- Utility files containing helpers in `./utilities/`
-- Sub-components of the component in it's own `./components/` subfolder
-- Hooks used in the component go to `./hooks/`
-- And so on...
-
-A more complex component could start to look like either of these examples. As always, choose the grouping or abstraction that makes sense to you.
+e.g. A subcomponent now needs a test? Apply rule #1 in the components folder 👇
 
 ```
-components
-└── ImportInventory
-    ├── index.ts
-    ├── ImportInventory.tsx
-    ├── components
-    │   ├── ImportCreated
-    │   │   ├── ImportCreated.tsx
-    │   │   └── ImportCreated.test.tsx
-    │   ├── ImportSubmitted
-    │   │   ├── ImportSubmitted.tsx
-    │   │   └── ImportSubmitted.test.tsx
-    │   └── InitialState
-    │       ├── InitialState.tsx
-    │       └── InitialState.test.tsx
-    ├── graphql
-    │   ├── InventoryImportCreateMutation.graphql
-    │   ├── InventoryImportSubmitMutation.graphql
-    │   └── InventoryStagedUploadMutation.graphql
-    └── tests
-        └── ImportInventory.test.tsx
-```
-
-or
-
-```
-components
-└── ImportInventory
-    ├── index.ts
-    ├── components
-    │   ├── ImportInventory.tsx
-    │   ├── ImportCreated.tsx
-    │   ├── ImportSubmitted.tsx
-    │   ├── InitialState.tsx
-    │   └── tests
-    │       ├── ImportCreated.test.tsx
-    │       ├── ImportSubmitted.test.tsx
-    │       ├── InitialState.test.tsx
-    │       └── ImportInventory.test.tsx
-    └── graphql
-        ├── InventoryImportCreateMutation.graphql
-        ├── InventoryImportSubmitMutation.graphql
-        └── InventoryStagedUploadMutation.graphql
+MyComponent/
+├── index.ts
+├── MyComponent.tsx
+├── tests
+│   ├── MyComponent-layout.test.tsx
+│   └── MyComponent-uploader.test.tsx
+├── components
+│   ├── SubComponent <---------------------- Notice how our SubComponent follows "Step #1"s structure?
+│   │   ├── index.ts
+│   │   ├── SubComponent.test.tsx
+│   │   └── SubComponent.tsx
+│   └── OtherSubComponent.tsx
+└── index.ts
 ```
 
 

--- a/handbook/Best practices/React/Organization.md
+++ b/handbook/Best practices/React/Organization.md
@@ -20,22 +20,22 @@ If you foresee this component growing quickly in complexity or needing a subcomp
 .
 └── components
     ├── ...
-    ├── MyComponent.js
+    ├── MyComponent.tsx
     └── tests
         ├── ...
-        └── MyComponent.test.js
+        └── MyComponent.test.tsx
 ```
 
 
 #### 2. Isolate your component to a folder (of the same name) as the component grows
 
 ```
-├── component.js
+├── component.tsx
 └── components
     └── MyComponent
-        ├── MyComponent.js
+        ├── MyComponent.tsx
         ├── MyComponent.scss
-        └── MyComponent.test.js
+        └── MyComponent.test.tsx
 ```
 
 When you move your component into it's own folder, you will need to figure out how to maintain all existing import paths.
@@ -48,9 +48,9 @@ import {MyComponent} from './components/MyComponent/MyComponent';
 
 You have several options to fix this problem:
 
-1. rename the component's filename from `MyComponent.js` to `index.js` to
-2. create an `index.js` inside the component's folder that exports `MyComponent.js`
-3. create a `components.js` file next to the component's folder that exports each component in the `components/` folder.
+1. rename the component's filename from `MyComponent.tsx` to `index.tsx` to
+2. create an `index.tsx` inside the component's folder that exports `MyComponent.tsx`
+3. create a `components.tsx` file next to the component's folder that exports each component in the `components/` folder.
 
 #### 3. As your component grows, group like-files in folders.
 

--- a/handbook/Best practices/React/Organization.md
+++ b/handbook/Best practices/React/Organization.md
@@ -4,11 +4,97 @@
 
 This section describes a sensible starting point for organizing a React application that supports server-side rendering.
 
-## `/app`
+## Application
 
-### `/app/components` and `<Component>/components`
+### React Components and Sub-Components
 
-TODO
+React Components should always exist in a `components/` folder, but the component's internal structure may change depending on their complexity.
+
+
+#### 1. Start with a file and a test
+
+At its simplest a component will exist as a component and a test at the `components/` level.
+
+If you foresee this component growing quickly in complexity or needing a subcomponent, feel free to jump straight to #2.
+```
+.
+└── components
+    ├── ...
+    ├── MyComponent.js
+    └── tests
+        ├── ...
+        └── MyComponent.test.js
+```
+
+
+#### 2. Isolate your component to a folder (of the same name) as the component grows
+
+When you move your component into it's own folder, you
+
+```
+├── component.js
+└── components
+    └── MyComponent.js
+        ├── MyComponent.js
+        ├── MyComponent.scss
+        └── MyComponent.test.js
+```
+
+#### 3. As your component grows, group like-files in folders.
+
+Common types to group inside a component:
+- Multiple tests into `./tests/`
+- graphQL queries and mutations in `./graphql/`
+- Subcomponents of the component in it's own `./components/` subfolder
+- utility files containing helpers in `./utils/`
+
+A more complex component could start to look like either of these examples. As always, choose the grouping or abstraction that makes sense to you.
+
+```
+components
+└── ImportInventory
+    ├── index.ts
+    ├── ImportInventory.tsx
+    ├── components
+    │   ├── ImportCreated
+    │   │   ├── ImportCreated.tsx
+    │   │   └── ImportCreated.test.tsx
+    │   ├── ImportSubmitted
+    │   │   ├── ImportSubmitted.tsx
+    │   │   └── ImportSubmitted.test.tsx
+    │   └── InitialState
+    │       ├── InitialState.tsx
+    │       └── InitialState.test.tsx
+    ├── graphql
+    │   ├── InventoryImportCreateMutation.graphql
+    │   ├── InventoryImportSubmitMutation.graphql
+    │   └── InventoryStagedUploadMutation.graphql
+    └── tests
+        └── ImportInventory.test.tsx
+```
+
+or
+
+```
+components
+└── ImportInventory
+    ├── index.ts
+    ├── components
+    │   ├── ImportInventory.tsx
+    │   ├── ImportCreated.tsx
+    │   ├── ImportSubmitted.tsx
+    │   ├── InitialState.tsx
+    │   └── tests
+    │       ├── ImportCreated.test.tsx
+    │       ├── ImportSubmitted.test.tsx
+    │       ├── InitialState.test.tsx
+    │       └── ImportInventory.test.tsx
+    └── graphql
+        ├── InventoryImportCreateMutation.graphql
+        ├── InventoryImportSubmitMutation.graphql
+        └── InventoryStagedUploadMutation.graphql
+```
+
 
 ### `/app/hooks` and `<Component>/hooks`
 


### PR DESCRIPTION
## What?

We were looking to web-foundation for some guidance on react component structure and found a `TODO`, so I figured I'd take a stab at some baseline rules for how to start structuring components and scaling the folder structure as it grows.

## Why?

My intention here is to set some simple rules for when and how to scale up a component, but also provide some reasoning for why you'd want to create folders. I want to discourage cargo-culting the folder structure of complex components when often we're creating relatively simple components. The intent of the rules are to provide guidance on when to group things without providing too much wiggle room for misinterpretation.

## Notes

Is this repo our new source of truth? Do we have any intention of keeping [`shopify/javascript`](https://github.com/shopify/javascript) up to date or getting docs from this repo published to https://development.shopify.io/?