### PR TITLE
Remove react-hot-loader

### DIFF
--- a/packages/babel-preset/README.md
+++ b/packages/babel-preset/README.md
@@ -95,7 +95,6 @@ This packages comes with several different presets for you to use, depending on 
 - `@shopify/babel-preset/react`: Adds plugins that transform React (including JSX). You can use this preset with the `@shopify/babel-preset/web` or `@shopify/babel-preset/node` configuration.
 
   This preset accepts an options object.
-  - `hot` : Will automatically add plugins to enable hot reloading of React components. Note that this requires you to have a recent version of `react-hot-loader` installed as a dependency in your project.
   - `pragma` : Replace the function used when compiling JSX expressions. Defaults to `React.createElement`.
   - `pragmaFrag`: Replace the function used when compiling JSX fragment expressions. Defaults to `React.Fragment`.
 
@@ -103,7 +102,7 @@ This packages comes with several different presets for you to use, depending on 
   {
     "babel": {
       "presets": [
-        ["@shopify/babel-preset/react", {"hot": true}]
+        ["@shopify/babel-preset/react", {"pragma": "React.createElement"}]
       ]
     }
   }

--- a/packages/babel-preset/README.md
+++ b/packages/babel-preset/README.md
@@ -102,7 +102,7 @@ This packages comes with several different presets for you to use, depending on 
   {
     "babel": {
       "presets": [
-        ["@shopify/babel-preset/react", {"pragma": "React.createElement"}]
+        ["@shopify/babel-preset/react", {"pragma": "h"}]
       ]
     }
   }

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -35,8 +35,5 @@
     "@babel/preset-typescript": "^7.7.4",
     "babel-plugin-react-test-id": "^1.0.2",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3"
-  },
-  "optionalDependencies": {
-    "react-hot-loader": "^4.6.0"
   }
 }

--- a/packages/babel-preset/react.js
+++ b/packages/babel-preset/react.js
@@ -14,12 +14,6 @@ module.exports = function shopifyReactPreset(api, options = {}) {
   }
 
   const isDevelopment = env === 'development' || env === 'test';
-  if (isDevelopment && options.hot) {
-    plugins.unshift(
-      // Enable hot loading
-      require.resolve('react-hot-loader/babel'),
-    );
-  }
 
   if (env !== 'test') {
     plugins.push(require.resolve('babel-plugin-react-test-id'));


### PR DESCRIPTION
As part of https://github.com/Shopify/sewing-kit/issues/1777 and the implementation of https://github.com/Shopify/sewing-kit/pull/1952 we wish to update to `react-fast-refresh` as provided by https://github.com/pmmmwh/react-refresh-webpack-plugin. This requires removing `react-hot-loader`.

This requires the usage of a new babel-transform `react-refresh/babel` and the aforementioned `react-refresh-webpack-plugin`. We are choosing to perform the logic to include these two packages within sewing-kit because of their dependent nature. 