### PR TITLE
Initial docs on TypeScript and project references

### DIFF
--- a/handbook/Best practices/TypeScript/Project-References.md
+++ b/handbook/Best practices/TypeScript/Project-References.md
@@ -2,35 +2,38 @@
 
 ## Table of contents
 
-1. [Why use Project References?](#why-use-project-referencesgi)
+1. [What are Project References?](#what-are-project-references)
 1. [Migrating a codebase](#migrating-a-codebase)
 1. [Tips](#tips)
 1. [Caveats](#caveats)
 
+## What are Project References?
 
-## Why use Project References?
+[Project References](https://www.typescriptlang.org/docs/handbook/project-references.html) provides built-in scalability for TypeScript. 
 
-Project References provides built-in scalability for TypeScript. It does this by providing developers tools to separate their code into smaller blocks. This enforces logical guidelines across the codebase which also results in healthier code over time. 
+### Code strucutre
 
-The logical guidelines enforced by Project References allow TypeScript tools to operate on smaller chunks of work at a time. This in turn improves responsiveness and tightens the feedback between the VSCode and the TypeScript Language Server. 
+Project references provide developers tools to separate their code into smaller blocks. This enforces logical guidelines across the codebase which results in healthier code over time. 
 
+### Performance
+
+The logical guidelines enforced by Project References enable [incremental compiles](https://www.typescriptlang.org/docs/handbook/project-references.html#build-mode-for-typescript). This in turn improves responsiveness and tightens the feedback between the VSCode and the TypeScript Language Server. 
 
 ## Migrating a codebase
 
 TypeScript's documentation and guidance on [Project References](https://www.typescriptlang.org/docs/handbook/project-references.html) are trivial to implement in new codebases. In larger codebases, leveraging Project References can be cumbersome. This section outlines our best practices on migrating a large codebase to gradually adopt Project References.
 
-
 ### Understanding your codebase
 
 In most large codebases, migrating to Project References in one go is likely, not feasible. The migration would have to be done gradually over time. 
 
-We recommend starting out by laying a foundation for the rest of the codebase to consume. This foundation generally includes the most widely used parts of your codebase. A good place to start might be the `packages/`, `tests/` or `app/utilities`. 
+We recommend starting out but identifying the leaf nodes in your project's depdency graph. These leaf nodes generally include the most widely used parts of your codebase. A good place to start might be the `packages/`, `tests/` or `app/utilities`. 
 
-In our experience, we've noticed that some `app/utilties` may be tightly coupled with `tests/` utilties, `app` code and `packages/` . In some cases even resulting in circular dependencies. We suggest you identifying some of the these utilties and extracting them into isolated project references hosted in `packages/@<project>-utilties`.
+In our experience, we've noticed that some `app/utilties` may be tightly coupled with `tests` utilties, `app` code and `packages/` . In some cases even resulting in circular dependencies. We suggest you identifying some of the these utilties and extracting them into isolated project references hosted in `packages/@<project>-utilties`.
 
-### Starting the foundation
+### Starting at the leaf nodes
 
-Start by creating an entrypoint for your project references. For this guide we'll assume our foundation that our app relies on consists of our projects `packages/` and `tests` directory. 
+Start by creating an entrypoint for your project references. For simplicity, let's assume the leave nodes of your app consists of a `packages/` and `tests` directory. 
 
 ```json
 // config/typescript/project-references.tsconfig.json
@@ -54,7 +57,7 @@ Start by creating an entrypoint for your project references. For this guide we'l
 }
 ```
 
-Whenever a project is referenced, that respective referenced folder requires a root level `tsconfig.json` specifying the depedendcies that project references in-turn. In the case of the above mentioned `project-references.tsconfig.json`, the `../../packages` path reference looks for a `packages/tsconfig.json`. 
+Whenever a project is referenced, that respective folder requires a root level `tsconfig.json` specifying the depedendcies that project references in-turn. In the case of the above mentioned `project-references.tsconfig.json`, the `../../packages` path reference looks for a `packages/tsconfig.json`. 
 
 ```json
 // packages/tsconfig.json
@@ -87,12 +90,11 @@ Whenever a project is referenced, that respective referenced folder requires a r
   "include": ["."],
   "references": [{"path": "../package-b"}]
 }
-
 ```
 
 ### Running a build
 
-With the foundation in place, you can now run the TypeScript compiler
+With the leaf nodes migrated to project references, you can now run the TypeScript compiler
 
 ```
 $ yarn run tsc -b config/typescript/project-references.tsconfig.json
@@ -100,7 +102,7 @@ $ yarn run tsc -b config/typescript/project-references.tsconfig.json
 
 > Protip: Use the ` --diagnostics` flag to get insight into what the compiler is doing. 
 
-It's very likely that you'll get a number of errors. The most common being that compiler can't find a module that your a project is referencing. The solution here would be to create a root level `tsconfig.json` for the module being depended on.Then add the reference to the `tsconfig.json` it in the project that fails to build. Keep in mind that you'll have the respect the following restrictions for project references:
+It's very likely that you'll get a number of errors. The most common being that compiler can't find a module that your a project is referencing. The solution here would be to create a root level `tsconfig.json` for the module being depended on. Then add the reference to the `tsconfig.json` it in the project that fails to build. Keep in mind that you'll have the respect the following restrictions for project references:
 
 * The `include`/`files` compiler option must include all the input files that the project reference relies on.
 * Any project that is referenced must itself have a references array (which may be empty).
@@ -108,7 +110,7 @@ It's very likely that you'll get a number of errors. The most common being that 
 
 ### Next steps
 
-With a reasonable foundation in place, the rest of the codebase should be better equipped to start migrating over. Start by deciding which top-level folders you would like to migrate. Then gradually pick which sections you would like to convert over and create a `tsconfig.json` for that respective section. 
+With the leaf nodes migrated, the rest of the codebase should be better equipped to start migrating over. Start by deciding which top-level folders you would like to migrate. Then gradually pick which sections you would like to convert over and create a `tsconfig.json` for that respective section. 
 
 ```
 // app/sections/tsconfig.json
@@ -142,14 +144,13 @@ With a reasonable foundation in place, the rest of the codebase should be better
 }
 ```
 
-
 ## Tips
 
 * We've built a VSCode plugin ([TypeTrack](https://github.com/Shopify/typetrack)) for teams to leverage when migrating their codebase to Project References
 
 * Use relative imports when referencing code within it's own project reference. 
 
-Eg
+Eg:
 ```
 // packages/@web-utilities/package-a/foo.ts
 
@@ -160,7 +161,6 @@ import {barThing} from '@web-utilities/package-a';
 import {barThing} from './bar-thing';
 ```
 
-
 ##  Caveats 
 
-Since depdendent projects make use of `.d.ts` files that are built from their dependencies you'll have to build a project after cloning it before VSCode can navigate the project in the editor without seeing spurious errors.
+Since dependent projects make use of `.d.ts` files that are built from their dependencies you'll have to build a project after cloning it before VSCode can navigate the project in the editor without seeing spurious errors.

--- a/handbook/Best practices/TypeScript/Project-References.md
+++ b/handbook/Best practices/TypeScript/Project-References.md
@@ -9,9 +9,9 @@
 
 ## What are Project References?
 
-[Project References](https://www.typescriptlang.org/docs/handbook/project-references.html) provides built-in scalability for TypeScript. 
+[Project References](https://www.typescriptlang.org/docs/handbook/project-references.html) is a new feature in TypeScript 3.0 that provides projects with built-in scalability by allowing you to better structure your code. By doing this, you can greatly improve build times, enforce logical separation between components, and organize your code in new and better ways.
 
-### Code strucutre
+### Code structure
 
 Project references provide developers tools to separate their code into smaller blocks. This enforces logical guidelines across the codebase which results in healthier code over time. 
 
@@ -27,7 +27,7 @@ TypeScript's documentation and guidance on [Project References](https://www.type
 
 In most large codebases, migrating to Project References in one go is likely, not feasible. The migration would have to be done gradually over time. 
 
-We recommend starting out but identifying the leaf nodes in your project's depdency graph. These leaf nodes generally include the most widely used parts of your codebase. A good place to start might be the `packages/`, `tests/` or `app/utilities`. 
+We recommend starting out but identifying the leaf nodes in your project's dependency graph. These leaf nodes generally include the most widely used parts of your codebase. A good place to start might be the `packages/`, `tests/` or `app/utilities`. 
 
 In our experience, we've noticed that some `app/utilties` may be tightly coupled with `tests` utilties, `app` code and `packages/` . In some cases even resulting in circular dependencies. We suggest you identifying some of the these utilties and extracting them into isolated project references hosted in `packages/@<project>-utilties`.
 
@@ -35,7 +35,7 @@ In our experience, we've noticed that some `app/utilties` may be tightly coupled
 
 Start by creating an entrypoint for your project references. For simplicity, let's assume the leave nodes of your app consists of a `packages/` and `tests` directory. 
 
-```json
+```jsonc
 // config/typescript/project-references.tsconfig.json
 
 {
@@ -57,9 +57,9 @@ Start by creating an entrypoint for your project references. For simplicity, let
 }
 ```
 
-Whenever a project is referenced, that respective folder requires a root level `tsconfig.json` specifying the depedendcies that project references in-turn. In the case of the above mentioned `project-references.tsconfig.json`, the `../../packages` path reference looks for a `packages/tsconfig.json`. 
+Whenever a project is referenced, that respective folder requires a root level `tsconfig.json` specifying the dependencies that project references in turn. In the case of the above mentioned `project-references.tsconfig.json`, the `../../packages` path reference looks for a `packages/tsconfig.json`. 
 
-```json
+```jsonc
 // packages/tsconfig.json
 
 {
@@ -73,7 +73,7 @@ Whenever a project is referenced, that respective folder requires a root level `
 }
 ```
 
-```json
+```jsonc
 // packages/@shopify/package-a/tsconfig.json
 
 {
@@ -96,7 +96,7 @@ Whenever a project is referenced, that respective folder requires a root level `
 
 With the leaf nodes migrated to project references, you can now run the TypeScript compiler
 
-```
+```bash
 $ yarn run tsc -b config/typescript/project-references.tsconfig.json
 ```
 
@@ -112,7 +112,7 @@ It's very likely that you'll get a number of errors. The most common being that 
 
 With the leaf nodes migrated, the rest of the codebase should be better equipped to start migrating over. Start by deciding which top-level folders you would like to migrate. Then gradually pick which sections you would like to convert over and create a `tsconfig.json` for that respective section. 
 
-```
+```jsonc
 // app/sections/tsconfig.json
 
 {

--- a/handbook/Best practices/TypeScript/Project-References.md
+++ b/handbook/Best practices/TypeScript/Project-References.md
@@ -3,6 +3,7 @@
 ## Table of contents
 
 1. [What are Project References?](#what-are-project-references)
+1. [Why use Project References?](#why-use-project-references)
 1. [Migrating a codebase](#migrating-a-codebase)
 1. [Tips](#tips)
 1. [Caveats](#caveats)
@@ -10,6 +11,8 @@
 ## What are Project References?
 
 [Project References](https://www.typescriptlang.org/docs/handbook/project-references.html) is a new feature in TypeScript 3.0 that provides projects with built-in scalability by allowing you to better structure your code. By doing this, you can greatly improve build times, enforce logical separation between components, and organize your code in new and better ways.
+
+## Why use Project References?
 
 ### Code structure
 

--- a/handbook/Best practices/TypeScript/Project-References.md
+++ b/handbook/Best practices/TypeScript/Project-References.md
@@ -1,0 +1,166 @@
+# Project References
+
+## Table of contents
+
+1. [Why use Project References?](#why-use-project-referencesgi)
+1. [Migrating a codebase](#migrating-a-codebase)
+1. [Tips](#tips)
+1. [Caveats](#caveats)
+
+
+## Why use Project References?
+
+Project References provides built-in scalability for TypeScript. It does this by providing developers tools to separate their code into smaller blocks. This enforces logical guidelines across the codebase which also results in healthier code over time. 
+
+The logical guidelines enforced by Project References allow TypeScript tools to operate on smaller chunks of work at a time. This in turn improves responsiveness and tightens the feedback between the VSCode and the TypeScript Language Server. 
+
+
+## Migrating a codebase
+
+TypeScript's documentation and guidance on [Project References](https://www.typescriptlang.org/docs/handbook/project-references.html) are trivial to implement in new codebases. In larger codebases, leveraging Project References can be cumbersome. This section outlines our best practices on migrating a large codebase to gradually adopt Project References.
+
+
+### Understanding your codebase
+
+In most large codebases, migrating to Project References in one go is likely, not feasible. The migration would have to be done gradually over time. 
+
+We recommend starting out by laying a foundation for the rest of the codebase to consume. This foundation generally includes the most widely used parts of your codebase. A good place to start might be the `packages/`, `tests/` or `app/utilities`. 
+
+In our experience, we've noticed that some `app/utilties` may be tightly coupled with `tests/` utilties, `app` code and `packages/` . In some cases even resulting in circular dependencies. We suggest you identifying some of the these utilties and extracting them into isolated project references hosted in `packages/@<project>-utilties`.
+
+### Starting the foundation
+
+Start by creating an entrypoint for your project references. For this guide we'll assume our foundation that our app relies on consists of our projects `packages/` and `tests` directory. 
+
+```json
+// config/typescript/project-references.tsconfig.json
+
+{
+  "extends": "./tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [{"path": "../../packages"}, {"path": "../../tests"}]
+}
+
+// config/typescript/tsconfig.base.json
+
+{
+  "extends": "@shopify/typescript-configs/application.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": false,
+    // remaining default config
+  }
+}
+```
+
+Whenever a project is referenced, that respective referenced folder requires a root level `tsconfig.json` specifying the depedendcies that project references in-turn. In the case of the above mentioned `project-references.tsconfig.json`, the `../../packages` path reference looks for a `packages/tsconfig.json`. 
+
+```json
+// packages/tsconfig.json
+
+{
+  "extends": "../config/typescript/tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {"path": "./@shopify/packages-a"},
+    {"path": "./@shopify/package-b"},
+  ]
+}
+```
+
+```json
+// packages/@shopify/package-a/tsconfig.json
+
+{
+  "extends": "../../../config/typescript/tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": "../../../",
+    "rootDir": "../../../",
+    "outDir": "../../../build/ts",
+    "resolveJsonModule": true,
+    "paths": {
+      "@shopify/package-b": ["packages/@shopify/package-b"],
+    }
+  },
+  "include": ["."],
+  "references": [{"path": "../package-b"}]
+}
+
+```
+
+### Running a build
+
+With the foundation in place, you can now run the TypeScript compiler
+
+```
+$ yarn run tsc -b config/typescript/project-references.tsconfig.json
+```
+
+> Protip: Use the ` --diagnostics` flag to get insight into what the compiler is doing. 
+
+It's very likely that you'll get a number of errors. The most common being that compiler can't find a module that your a project is referencing. The solution here would be to create a root level `tsconfig.json` for the module being depended on.Then add the reference to the `tsconfig.json` it in the project that fails to build. Keep in mind that you'll have the respect the following restrictions for project references:
+
+* The `include`/`files` compiler option must include all the input files that the project reference relies on.
+* Any project that is referenced must itself have a references array (which may be empty).
+* Specify the path mapping entries for module name to locations relative to the baseUrl. This is set in `#compilerOptions#paths`.
+
+### Next steps
+
+With a reasonable foundation in place, the rest of the codebase should be better equipped to start migrating over. Start by deciding which top-level folders you would like to migrate. Then gradually pick which sections you would like to convert over and create a `tsconfig.json` for that respective section. 
+
+```
+// app/sections/tsconfig.json
+
+{
+  "extends": "../../config/typescript/tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {"path": "./Home"}
+  ]
+}
+
+// app/sections/Home/tsconfig.json
+
+{
+  "extends": "../../../config/typescript/tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": "../../../",
+    "rootDir": "../../../",
+    "outDir": "../../../build/ts",
+    "resolveJsonModule": true,
+    "paths": {
+      // List out all the project refeece path this section references
+    }
+  },
+  "include": ["."],
+  "references": [
+    // Include all the projec references this section relies on
+  ]
+}
+```
+
+
+## Tips
+
+* We've built a VSCode plugin ([TypeTrack](https://github.com/Shopify/typetrack)) for teams to leverage when migrating their codebase to Project References
+
+* Use relative imports when referencing code within it's own project reference. 
+
+Eg
+```
+// packages/@web-utilities/package-a/foo.ts
+
+// bad
+import {barThing} from '@web-utilities/package-a';
+
+// good
+import {barThing} from './bar-thing';
+```
+
+
+##  Caveats 
+
+Since depdendent projects make use of `.d.ts` files that are built from their dependencies you'll have to build a project after cloning it before VSCode can navigate the project in the editor without seeing spurious errors.

--- a/handbook/Best practices/TypeScript/README.md
+++ b/handbook/Best practices/TypeScript/README.md
@@ -1,6 +1,6 @@
 # TypeScript
 
-[TypeScript](https://www.typescriptlang.org/) is a typed superset of JavaScript that we strongly advise projects to use in favour of vanilla JavaScript. This enables projects to leverage TypeScript's compiler to help catch a number of potential bugs and errors in projects well before it ships. In complement with TypeScript, the [VSCode editor](https://code.visualstudio.com/docs/languages/typescript) provides TypeScript language-specific features such as inline feedback from TypeScript typechecker. 
+[TypeScript](https://www.typescriptlang.org/) is a typed superset of JavaScript that we strongly advise projects to use in favour of vanilla JavaScript. This enables projects to leverage TypeScript's compiler to help catch a number of potential bugs and errors in projects well before it ships. In complement with TypeScript, the [VSCode editor](https://code.visualstudio.com/docs/languages/typescript) provides TypeScript language-specific features such as inline feedback from TypeScript's typechecker. 
 
 
 ## Table of contents

--- a/handbook/Best practices/TypeScript/README.md
+++ b/handbook/Best practices/TypeScript/README.md
@@ -1,0 +1,30 @@
+# TypeScript
+
+[TypeScript](https://www.typescriptlang.org/) is a typed superset of JavaScript that we strongly advise projects to use in favour of vanilla JavaScript. This enables projects to leverage TypeScript's compiler to help catch a number of potential bugs and errors in projects well before it ships. In complement with TypeScript, the [VSCode editor](https://code.visualstudio.com/docs/languages/typescript) provides TypeScript language-specific features such as inline feedback from TypeScript typechecker. 
+
+
+## Table of contents
+
+1. [Purpose of this guide](#purpose-of-this-guide)
+1. [Complementary packages](#complementary-packages)
+1. [Scaling large codebases](#scaling-large-codebases)
+
+## Purpose of this guide
+
+This guide covers Shopify's approach to using TypeScript. It also highlights our suite of TypeScript related packages and how we use [Project References](https://www.typescriptlang.org/docs/handbook/project-references.html) to scale our large TypeScript codebases. 
+
+
+## Complementary packages
+
+Additional tooling is heavily integrated into TypeScript projects at Shopify to improve our development experience and developer confidence.
+
+* [`@shopify/typescript-configs`](https://github.com/Shopify/web-foundation/tree/master/packages/typescript-configs): Common base configuration files to simplify TypeScript project setup.
+* [`@shopify/eslint-plugin` TypeScript config](https://github.com/Shopify/web-foundation/blob/master/packages/eslint-plugin/lib/config/typescript.js) ESLint config for TypeScript codebases
+* [`graphql-typescript-definitions`](https://github.com/Shopify/graphql-tools-web/tree/master/packages/graphql-typescript-definitions): Tooling to generate TypeScript definition files from .graphql documents
+* [`@shopify/useful-types`](https://github.com/Shopify/quilt/tree/master/packages/useful-types): A few handy TypeScript types.
+
+## Scaling large codebases
+
+As TypeScript projects grow in size, it's not uncommon to experience longer typechecking, compile times, increased memory usage, and most noticeably, slower feedback in VSCode's TypeScript Language features. To address these issues TypeScript provides [Project References](https://www.typescriptlang.org/docs/handbook/project-references.html). To leverage this in your project, check out our [guide on Project References](./Project-References.md)
+
+


### PR DESCRIPTION
Closes https://github.com/Shopify/web-foundations-private/issues/6

This PR creates some a TypeScript folder in our handbook with some introductory context on why we use TypeScript. Then it dives into scaling large codebases with Project References.