### PR TITLE
[eslint-plugin] adding new options to strict-component-boundaries

### DIFF
--- a/packages/eslint-plugin/tests/lib/rules/strict-component-boundaries.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/strict-component-boundaries.test.js
@@ -62,6 +62,18 @@ ruleTester.run('strict-component-boundaries', rule, {
         'basic-app/app/components/Foo/components/Bar/index.js',
       ),
     },
+    {
+      code: `import someThing from './components/Foo';`,
+      parserOptions,
+      options: [{allow: ['components/\\w+$']}],
+      filename: fixtureFile('basic-app/app/index.js'),
+    },
+    {
+      code: `import someThing from './components/Foo';`,
+      parserOptions,
+      options: [{maxDepth: 2}],
+      filename: fixtureFile('basic-app/app/index.js'),
+    },
   ],
   invalid: [
     {
@@ -87,6 +99,20 @@ ruleTester.run('strict-component-boundaries', rule, {
       parserOptions,
       errors,
       filename: fixtureFile('basic-app/app/components/Foo/index.js'),
+    },
+    {
+      code: `import someThing from './components/Foo/Foo';`,
+      parserOptions,
+      options: [{allow: ['components/\\w+$']}],
+      errors,
+      filename: fixtureFile('basic-app/app/index.js'),
+    },
+    {
+      code: `import someThing from './components/Foo/Foo';`,
+      parserOptions,
+      options: [{maxDepth: 2}],
+      errors,
+      filename: fixtureFile('basic-app/app/index.js'),
     },
   ],
 });


### PR DESCRIPTION
adding the following options to `strict-component-boundaries` list rule
- `allow` (`string[]`): list of patterns to automatically allow (i.e., `['section/Foo/.*']`)
- `maxDepth` (`number`): max allowed inclusive depth for `components` boundary (default is `1`)
  - `components` would be depth `1` since there is a single inclusive `components` level 
  - `components/Foo` would be depth `2`
  - `sections/Foo/components/Bar/Baz` would be depth `3`
