### PR TITLE
Stylelint: Allow hypens in classnames

### DIFF
--- a/packages/stylelint-plugin/CHANGELOG.md
+++ b/packages/stylelint-plugin/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Loosen the `selector-class-pattern` rule to allow for hypens in class names ([#153](https://github.com/Shopify/web-foundation/pull/153))
 
 ## [8.0.0] - 2020-03-28
 

--- a/packages/stylelint-plugin/config/selector.js
+++ b/packages/stylelint-plugin/config/selector.js
@@ -12,7 +12,7 @@ module.exports = {
   // Require or disallow quotes for attribute values.
   'selector-attribute-quotes': 'always',
   // Specify a pattern for class selectors.
-  'selector-class-pattern': /^[a-zA-Z][a-zA-Z0-9]+$/,
+  'selector-class-pattern': /^[a-zA-Z][a-zA-Z0-9-]+$/,
   // Require a single space or disallow whitespace after the combinators of selectors.
   'selector-combinator-space-after': 'always',
   // Require a single space or disallow whitespace before the combinators of selectors.


### PR DESCRIPTION
This updates the allowed classnames to match what [polaris-react has been using](https://github.com/Shopify/polaris-react/blob/19f899e589e05fcbab10641ac467ce32fb1b8def/package.json#L84) for a long time.

We find it useful for showing [variant states for an element](https://github.com/Shopify/polaris-react/blob/master/src/components/ResourceList/ResourceList.scss#L41) (kinda like modifiers in BEM, but with a slightly different syntax).

Considering lots of people fork polaris components I figure not showering them with lint errors as they copy components from polaris-react into their repo would be useful.