### PR TITLE
Add linting for ensuring consistent chaneglog formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   "scripts": {
     "test": "jest",
     "lint": "eslint '**/*.{js,jsx,ts,tsx}'",
+    "lint:changelogs": "node scripts/lint-changelogs.js",
     "check": "lerna run check",
     "generate": "plop",
-    "release": "lerna publish",
+    "release": "yarn lint:changelogs && lerna publish",
     "release-beta": "lerna publish --dist-tag beta",
     "generate:package": "plop package && yarn plop docs",
     "tophat": "tophat"
@@ -21,6 +22,8 @@
     "codecov": "^3.6.5",
     "eslint": "^6.8.0",
     "eslint-plugin-prettier": "^3.1.2",
+    "fs-extra": "^9.0.0",
+    "glob": "^7.1.6",
     "jest": "^25.2.0",
     "lerna": "^2.11.0",
     "plop": "^2.6.0",

--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
 <!-- ## [Unreleased] -->
 
 ## [23.0.0] - 2020-04-23
@@ -12,8 +17,7 @@ Remove `react-hot-loader` since `react-fast-refresh` is now used in sewing-kit [
 
 This package has been renamed from `babel-preset-shopify` to `@shopify/babel-preset`.
 
-
-### Before
+Before:
 
 ```
 module.exports = {
@@ -21,79 +25,79 @@ module.exports = {
 };
 ```
 
-#### After
+After:
+
 ```
 module.exports = {
   presets: [['@shopify/babel-preset/...']],
 };
 ```
 
-## 21.0.0
+## [21.0.0]
 
 ### Added
 
 - Added support for null coalescing and optional chaining operators [[#48](https://github.com/Shopify/babel-preset-shopify/pull/48)]
 
-### Updated
+### Changed
 
-- `@babel/core`, `@babel/preset-env`, presets, and plugins updated to the latest `7.7.x` versions [[#47](https://github.com/Shopify/babel-preset-shopify/pull/47)]
+- Updated `@babel/core`, `@babel/preset-env`, presets, and plugins updated to the latest `7.7.x` versions [[#47](https://github.com/Shopify/babel-preset-shopify/pull/47)]
 
-## 20.1.0 - 2019-09-24
+## [20.1.0] - 2019-09-24
 
 - Pass `browsers` web preset config string directly into babel-preset-env's targets option, so that if it is unset we shall read honor browserslist config in package.json / .browserslistrc
 
-## 20.0.0 - 2019-06-03
+## [20.0.0] - 2019-06-03
 
 - Add `babel-plugin-dynamic-import-node` to the node preset. This was originally added in 19.1.0 then reverted in 19.1.1 as it was a breaking change in some circumstances
 
-## 19.1.1 - 2019-06-03
+## [19.1.1] - 2019-06-03
 
 - Revert Adding `babel-plugin-dynamic-import-node` to the node preset as this may be a breaking change in some circumstances
 
-## 19.1.0 - 2019-05-29
+## [19.1.0] - 2019-05-29
 
 - Added `typescript` option to node and web presets to allow babel to read typescript files when set to true.
 - Added `babel-plugin-dynamic-import-node` to the node preset
 - Removed `@babel/plugin-proposal-optional-catch-binding` because it is already handled by `@babel/preset-env` if you specify an environment where it is needed.
 
-## 19.0.1 - 2019-05-23
+## [19.0.1] - 2019-05-23
 
 - Added `@babel/plugin-proposal-optional-catch-binding` to `node` and `web` presets
 
-## 19.0.0 - 2019-05-06
+## [19.0.0] - 2019-05-06
 
 - Switched the default `useBuiltIns` option back to `entry`, since it has a smaller bundle impact on large applications
 
-## 18.1.1 - 2019-05-03
+## [18.1.1] - 2019-05-03
 
 - `web` preset now accepts a `useBuiltIn` value (default = `usage`)
 
-## 18.1.0 - 2019-04-22
+## [18.1.0] - 2019-04-22
 
 ### Added
 
 - `node` and `web` presets now accept a `corejs` option (default = `2`)
 
-## 18.0.0 - 2019-03-19
+## [18.0.0] - 2019-03-19
 
 ### Changed
 
 - `node` and `web` presets now use `useBuiltIns: 'usage'` for including `corejs` polyfills.
 
-## 17.0.1 - 2019-01-09
+## [17.0.1] - 2019-01-09
 
 ### Fixed
 
 - Honor the `envName` defined in your babel config.
 
-## 17.0.0 - 2019-01-03
+## [17.0.0] - 2019-01-03
 
 ### Changed
 
 - All presets now only work with Babel version 7 or greater.
 - `browsers` are no longer hardcoded to those supported by Shopify’s admin for the purposes of the `shopify/web` preset. You must provide a [browserslist](https://github.com/browserslist/browserslist)-compatible configuration within your project, which will be used automatically when running Babel with this preset. Projects can use [`@shopify/browserslist-config`](https://github.com/Shopify/browserslist-config) to get the same support as Shopify’s admin.
 - The `shopify/web` preset no longer includes plugins for Stage 3 features. The only non-standard features included in this preset are class properties and dynamic imports.
-
 
 ### Removed
 
@@ -103,13 +107,13 @@ module.exports = {
 
 - The `shopify/react` preset now accepts a `pragmaFrag` option for specifying the component to use in JSX fragment expressions.
 
-## 16.7.0 - 2018-12-18
+## [16.7.0] - 2018-12-18
 
 ### Changed
 
 - Removed `babel-plugin-transform-react-pure-to-component`.
 
-## 16.6.0 - 2018-10-11
+## [16.6.0] - 2018-10-11
 
 ### Changed
 
@@ -119,52 +123,53 @@ module.exports = {
   - `babel-preset-env` 1.5.2 => 1.7.0.
 
 
-### Internals
+### Chore
 
 - Switch from Circle CI to Travis.
 
-## 16.5.0 - 2018-05-01
+## [16.5.0] - 2018-05-01
 
-### Internals
+### Chore
 
 - Added `publishConfig` to fix deployments.
 
-## 16.4.0 - 2018-05-01
+## [16.4.0] - 2018-05-01
 
 ### Added
 
 - `shopify/react` preset now accepts an additional option, `pragma`. Defaults to `React.createElement`.
 
-## 16.3.0 - 2018-03-14
+## [16.3.0] - 2018-03-14
 
 ### Added
 
 - `shopify/web` and `shopify/node` now accept an additional option, `debug`. When passed, this enables `babel-preset-env`'s debugging to show why transforms are being included in a project. Defaults to `false` (current behaviour).
 
-## 16.2.0 - 2017-08-23
+## [16.2.0] - 2017-08-23
 
 ### Added
+
 - Added `babel-plugin-syntax-dynamic-import` to the web config.
 
-## 16.1.0 - 2017-06-08
+## [16.1.0] - 2017-06-08
 
 ### Added
 
 - Added a Babel plugin to remove `testID` props in non-test environments.
 
-## 16.0.2 - 2017-02-18
+## [16.0.2] - 2017-02-18
 
-### Updated
+### Changed
 
 - Integrated bugfix from most recent version of `babel-plugin-transform-react-pure-to-component`.
 
-## 16.0.1 - 2017-02-17
+## [16.0.1] - 2017-02-17
 
 ### Fixed
 
 - `shopify/web` and `shopify/node` now correctly default the `modules` option to `'commonjs'` instead of `true`.
 
-## 16.0.0 - 2017-02-07
+## [16.0.0] - 2017-02-07
 
 ### Added
 
@@ -173,11 +178,11 @@ module.exports = {
 - `shopify/web` now accepts an additional option, `browsers` (an array of [`browserslist`](https://github.com/ai/browserslist) strings) which specifies what browsers to transpile for (defaults to the browsers supported by Shopify’s admin).
 
 
-### Updated
+### Changed
 
 - `shopify/web` and `shopify/node` presets now use [`babel-preset-env`](https://github.com/babel/babel-preset-env) to transpile only the features needed for the target environment.
 - Updated all versions of dependend-on plugins and presets.
 
-## 15.0.1
+## [15.0.1]
 
 - Initial move from combined `javascript` repo.

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
 <!-- ## [Unreleased] -->
 
 ## [36.1.0] - 2020-05-05
@@ -18,7 +23,7 @@
 
 This package has been renamed from `eslint-plugin-shopify` to `@shopify/eslint-plugin`. You must update you eslint config to account for the new name, when referencing the plugin and individual rules.
 
-### Before
+Before:
 
 ```
 plugins: ['shopify'],
@@ -28,7 +33,8 @@ rules: {
 }
 ```
 
-#### After
+After:
+
 ```
 plugins: ['@shopify'],
 extends: ['plugin:@shopify/...'],
@@ -55,7 +61,8 @@ rules: {
 - changed `no-vague-titles` rule to catch blacklisted **words** (instead of **sequences**) in the title ([514](https://github.com/Shopify/eslint-plugin-shopify/pull/514))
 - removed `jest/no-empty-title` and renamed `jest/require-tothrow-message` to `jest/require-to-throw-message` ([499](https://github.com/Shopify/eslint-plugin-shopify/pull/499))
 
-### New Rules
+### Added
+
 The followiing new rules were introduced in `eslint@6.7.0`. More information can be found on the [eslint blog](https://eslint.org/blog/2019/11/eslint-v6.7.0-released).
 - [`grouped-accessor-pairs`](https://eslint.org/docs/rules/grouped-accessor-pairs)
 - [`no-constructor-return`](https://eslint.org/docs/rules/no-constructor-return)
@@ -83,7 +90,7 @@ The followiing new rules were introduced in `eslint@6.7.0`. More information can
 
 **After this change** Final parser is `babel-eslint` for only `.graphql` files while `@typescript-eslint/parser` is set for all `.ts` and `.tsx` files. This should not cause any parser-related errors :)
 
-### New Rules
+### Added
 
 - `shopify/no-all-mocks-methods` ([#204](https://github.com/Shopify/eslint-plugin-shopify/pull/204))
 - `shopify/no-namespace-imports` Prevent namespace import declarations. ([262](https://github.com/Shopify/eslint-plugin-shopify/pull/262))
@@ -97,7 +104,7 @@ The followiing new rules were introduced in `eslint@6.7.0`. More information can
 
 ## [31.0.0] - 2019-10-23
 
-### Using `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin`
+### Breaking Change
 
 - **Breaking Change** Updated from `eslint-plugin-typescript` to `@typescript-eslint/eslint-plugin`. If you have any rules defined under the typescript namespace, you will need to change those to use the new `@typescript-eslint` namespace.
 
@@ -116,8 +123,6 @@ Will become:
   "@typescript-eslint/restrict-plus-operands": "error"
 }
 ```
-
-### Config Changes
 
 - **Breaking Change** The `plugin:shopify/react` is no longer a core config and must augment one of the `plugin:shopify/typescript` or `plugin:shopify/esnext` configs. See examples below
 
@@ -148,7 +153,7 @@ _Example config for react with typescript projects:_
 - **Note** If using the `plugin:shopify/typescript-type-checking` augmented config, you must specify a path to your tsconfig.json file in the "project" property of "parserOptions"
 
 
-### New Rules
+### Added
 
 - `jest/no-standalone-expect` Prevents `expect` statements outside of a `test` or `it` block ([368](https://github.com/Shopify/eslint-plugin-shopify/pull/368))
 - `jest/no-expect-resolves` Avoid using `expect().resolves` ([370](https://github.com/Shopify/eslint-plugin-shopify/pull/370))
@@ -161,6 +166,7 @@ _Example config for react with typescript projects:_
 ## [30.0.0] - 2019-06-24
 
 ### Changed
+
 - Enabled `jest/no-export` rule ([344](https://github.com/Shopify/eslint-plugin-shopify/pull/344))
 - [Major] depreciated `shopify/jest/no-try-expect` in favour of [`jest/no-try-expect`](https://github.com/jest-community/eslint-plugin-jest/pull/) ([331](https://github.com/jest-community/eslint-plugin-jest/pull/331))
 - [Major] depreciated `shopify/jest/no-if` in favour of [`jest/no-if`](https://github.com/jest-community/eslint-plugin-jest/pull/293) ([347](https://github.com/Shopify/eslint-plugin-shopify/pull/347))
@@ -169,6 +175,7 @@ _Example config for react with typescript projects:_
 - Enabled `jest/no-duplicate-hooks` rule ([344](https://github.com/Shopify/eslint-plugin-shopify/pull/344))
 
 ### Fixed
+
 - [Patch] Fix `jest/no-if` from falsely reporting if statements inside of functions ([331](https://github.com/Shopify/eslint-plugin-shopify/pull/331))
 
 ## [29.0.2] - 2019-06-18
@@ -289,7 +296,7 @@ _Example config for react with typescript projects:_
   ```
   More information on this change can be found [in this eslint blog post](https://eslint.org/blog/2019/01/future-typescript-eslint]).
 
-#### New rules
+#### Added
 
 * `shopify/jest/no-if` ([#232](https://github.com/Shopify/eslint-plugin-shopify/pull/232))
 
@@ -445,6 +452,7 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 ## [24.0.0] - 2018-08-30
 
 ### Fixed
+
 * `plugin:shopify/flow` now disables rules checked by Flow's static analyzer. ([#135](https://github.com/Shopify/eslint-plugin-shopify/pull/135))
 * `plugin:shopify/prettier` and `plugin:shopify/typescript-prettier` defer missing semicolon rules to a project´s `.prettierrc`. ([#135](https://github.com/Shopify/eslint-plugin-shopify/pull/135))
 * Updated `strict-component-boundaries` to exclude fixture imports. ([#117](https://github.com/Shopify/eslint-plugin-shopify/pull/117))
@@ -452,10 +460,12 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 * Updated `jest/no-vague-titles` to support `.each` syntax. ([#148](https://github.com/Shopify/eslint-plugin-shopify/pull/148))
 
 ### Changed
+
 * Namespaced `prefer-pascal-case-enums` and `prefer-singular-enums` under `typescript`. ([#141](https://github.com/Shopify/eslint-plugin-shopify/pull/141))
 * **Breaking:** Updated to eslint `v5.4.0`. Consuming projects must be using [supported](https://eslint.org/docs/user-guide/migrating-to-5.0.0#-nodejs-4-is-no-longer-supported) node versions, we recommend `^8.10.0`. See details on the v4 to v5 [migration guide](https://eslint.org/docs/user-guide/migrating-to-5.0.0). ([#151](https://github.com/Shopify/eslint-plugin-shopify/pull/151))
 
 ### Added
+
 * `shopify/prefer-singular-enums` ([#132](https://github.com/Shopify/eslint-plugin-shopify/pull/132))
 * `shopify/react-no-multiple-render-methods` ([#134](https://github.com/Shopify/eslint-plugin-shopify/pull/134))
 
@@ -494,46 +504,57 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 ## [23.1.0] - 2018-08-02
 
 ### Fixed
+
 * Updated `typescript-eslint-parser` dependency to version 17.0.1 in order to support TypeScript 3. ([#121](https://github.com/Shopify/eslint-plugin-shopify/pull/121))
 * Removed default prettier configurations. `plugin:shopify/prettier` and `plugin:shopify/typescript-prettier` now defer Prettier's config to a project's `.prettierrc`. ([#121](https://github.com/Shopify/eslint-plugin-shopify/pull/121))
 
 ### Changed
+
 * Included `all` as a vague term for `no-vague-titles` ([#114](https://github.com/Shopify/eslint-plugin-shopify/pull/114))
 
 ## [23.0.0] - 2018-07-16
+
 * **Breaking** `eslint-plugin-shopify` will no longer install `prettier` as a dependency. Please ensure you have added `prettier` to your `package.json` if you wish to use it.
 
 ### Added
+
 * `shopify/jsx-prefer-fragment-wrappers` ([#94](https://github.com/Shopify/eslint-plugin-shopify/pull/94))
 * `shopify/jest/no-vague-titles` ([#93](https://github.com/Shopify/eslint-plugin-shopify/pull/93))
 * `shopify/strict-component-boundaries` ([#98](https://github.com/Shopify/eslint-plugin-shopify/pull/98))
 
 ### Changed
+
 * **Breaking** Moved prettier to be a peerDependency, this avoids the potential for having multiple versions of prettier in the dependency graph. If you use prettier you will need to ensure you have it installed in your project as eslint-plugin-shopify will no longer install it for you ([#107](https://github.com/Shopify/eslint-plugin-shopify/pull/107))
 * **Breaking** Updated `typescript-eslint-parser` to support `typescript@2.9.1` ([#102](https://github.com/Shopify/eslint-plugin-shopify/pull/102))
 
 ## [22.1.0] - 2018-06-08
 
 ### Fixed
+
 * Updated `eslint-plugin-sort-class-members` dependency to version 1.3.1 in order to support node 10.
 
 ### Added
+
 * `shopify/prefer-pascal-case-enums` ([#96](https://github.com/Shopify/eslint-plugin-shopify/pull/96))
 * `shopify/react-prefer-private-members` ([#95](https://github.com/Shopify/eslint-plugin-shopify/pull/95))
 
 ## [22.0.0]
+
 * Updated dependencies
 * Added support for TypeScript 2.8
 
 ## [21.0.1] - 2018-04-25
+
 * Fixed the publish config for the package.
 
 ## [21.0.0] - 2018-04-25
 
 ### Added
+
 * `shopify/jsx-no-hardcoded-content` now accepts a `dom` option that allows specifying attributes on DOM elements and Web Components to be checked for hardcoded content.
 
 ### Removed
+
 * **Breaking:** turned off four rules that previously triggered errors in all cases:
   * `shopify/react-type-state` (TypeScript now addresses the issue this rule was meant to catch)
   * `promise/always-return`
@@ -544,9 +565,11 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
   * `no-process-env` (turned off for the `webpack` and `node` configs as both targets can benefit from use of `process.env`)
 
 ### Fixed
+
 * Fixed an issue where various rules were not correctly resolving paths in `node_modules`.
 
 ## [20.0.0] - 2018-03-15
+
 * **Breaking:** the version of TypeScript supported by this plugin is 2.7.x (in line with [typescript-eslint-parser](https://github.com/eslint/typescript-eslint-parser)’s TypeScript support)
 * Updated dependencies that support the new ESLint documentation URL metadata. Errors from these plugins are accompanied by a link to the documentation for the broken rule.
 * Dependencies are now strictly versioned for tighter control over the exact rules the plugin enforces.
@@ -590,11 +613,13 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 ## [19.0.1] - 2018-03-12
 
 ### Fixed
+
 * `shopify/jsx-no-hardcoded-content` rule now does not warn on all-whitespace strings as children. This was causing issues with indented JSX content, and is typically not an issue for different locales.
 
 ## [19.0.0] - 2018-01-17
 
 ### Added
+
 * `shopify/jest` config with [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest) rules:
   - `jest/no-disabled-tests` (disabled)
   - `jest/no-focused-tests`
@@ -640,6 +665,7 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 [`react/jsx-curly-brace-presence`]: https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules/jsx-curly-brace-presence.md
 
 ### Changed
+
 * Updated dependencies to their latest versions (full details in [#63](https://github.com/Shopify/eslint-plugin-shopify/pull/63))
 * **Breaking:** `node.js` minimum supported node version update to `8.9.4` (LTS).
 * **Breaking:** Changed `eslint-config-shopify` codebase to `trailingComma: 'all'` and drop support for Node.js 6
@@ -653,7 +679,7 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
     const foo = myArray.map((foo) => {});
     ```
 
-    #### ⚠️ Upgrade path
+    ⚠️ Upgrade path:
 
     Your project config files (`package.json`, `.prettierrc`, `.eslintrc`…)
     may need to be updated like so:
@@ -669,23 +695,29 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 ## [18.3.1] - 2017-12-21
 
 ### Changed
+
 * Changed `eslint-config-shopify` codebase to follow es5 trailingComma [[#61](https://github.com/Shopify/eslint-plugin-shopify/pull/61)]
 
 ## [18.3.0] - 2017-12-18
 
 ### Added
+
 * Added `shopify/no-debugger`, which behaves the same as ESLint's `no-debugger` but without a fixer.
 
 ## [18.2.0] - 2017-12-04
+
 ### Added
+
 * Added a `typescript-prettier` config to run prettier against typescript projects.
 
 ## [18.1.0] - 2017-12-01
 
 ### Added
+
 * Added a `typescript` and `typescript-react` config [[#54](https://github.com/Shopify/eslint-plugin-shopify/pull/54)]
 
 ### Changed
+
 * `plugin:shopify/prettier` will now enforce trailing commas in function parameter calls [[#55](https://github.com/Shopify/eslint-plugin-shopify/pull/55)]
 * `comma-dangle` will now enforce multi-line function parameters [[#55](https://github.com/Shopify/eslint-plugin-shopify/pull/55)]
 * Removed `plugin:shopify/esnext` as an included extension of the `plugin:shopify/prettier` config. `plugin:shopify/esnext` must now be extended by the consumer to use the `plugin:shopify/prettier`. [[#53](https://github.com/Shopify/eslint-plugin-shopify/pull/53)]
@@ -701,15 +733,21 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
   ```
 
 ## [18.0.0] - 2017-10-31
+
 ### Changed
+
 * Turned off `class-methods-use-this`
 
 ## [17.2.1] - 2017-10-30
+
 ### Changed
+
 * Turned off `babel/semi` rule in prettier config
 
 ## [17.2.0] - 2017-10-25
+
 ### Added
+
 * Added a prettier config [[#46](https://github.com/Shopify/eslint-plugin-shopify/pull/46)]
 
 Example:
@@ -722,17 +760,20 @@ Example:
 ```
 
 ### Changed
+
 * Replace all `warn` with `error` [[#48](https://github.com/Shopify/eslint-plugin-shopify/pull/48)]
 * `space-before-function-paren` now uses `asyncArrow` option (eg. `async () => {}`) [[#43](https://github.com/Shopify/eslint-plugin-shopify/pull/43)]
 * Enable `padding-line-between-statements` for directives.  [[#44](https://github.com/Shopify/eslint-plugin-shopify/pull/44)]
 
 ### Removed
+
 * `lines-around-directive` was deprecated in ESLint `v4.0.0`. [[#44](https://github.com/Shopify/eslint-plugin-shopify/pull/44)]
 
 
 ## [17.1.0] - 2017-09-19
 
 ### Added
+
 * New rules ([#41](https://github.com/Shopify/eslint-plugin-shopify/pull/41)):
   - `import/no-anonymous-default-export`
   - `jsx-a11y/anchor-is-valid`
@@ -756,6 +797,7 @@ Example:
 
 
 ### Changed
+
 - Updated dependencies ([#41](https://github.com/Shopify/eslint-plugin-shopify/pull/41)):
   - `eslint`
   - `babel-eslint`
@@ -766,10 +808,13 @@ Example:
 - `jquery-dollar-sign-reference` no longer flags assignments from `await` expressions
 
 ### Removed
+
 - `jsx-a11y/href-no-hash` replaced with `jsx-a11y/anchor-is-valid`
 
 ## [17.0.0] - 2017-08-17
+
 ### Changed
+
 - `eslint` upgrade to `4.3.0`
 - `node.js` minimum supported node version update to `6.11.1` (LTS).
 - Update dependencies:
@@ -782,11 +827,15 @@ Example:
 
 
 ## [16.0.1] - 2017-05-29
+
 ### Changed
+
 - Turned off [`prefer-destructuring`](http://eslint.org/docs/rules/prefer-destructuring) ([#30](https://github.com/Shopify/eslint-plugin-shopify/pull/30))
 
 ## [16.0.0] - 2017-05-16
+
 ### Added
+
 - New rule: [`babel/semi`](https://github.com/babel/eslint-plugin-babel/releases/tag/v4.1.0)
 - New rule: [`flowtype/no-types-missing-file-annotation`](https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-no-types-missing-file-annotation)
 - New rule: [`jsx-a11y/accessible-emoji`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/accessible-emoji.md)
@@ -818,6 +867,7 @@ Example:
 - New rule: [`template-tag-spacing`](http://eslint.org/docs/rules/template-tag-spacing)
 
 ### Removed
+
 - Deprecated: [`babel/no-await-in-loop`](https://github.com/babel/eslint-plugin-babel/releases/tag/v4.1.1)
 - Deprecated: [`jsx-a11y/img-has-alt`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md#500--2017-05-05)
 - Deprecated: [`jsx-a11y/onclick-has-focus`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md#500--2017-05-05)
@@ -826,15 +876,21 @@ Example:
 
 
 ## [15.2.0] - 2017-03-06
+
 ### Changed
+
 - `eslint` upgrade to `3.17.x`
 
 ## [15.1.2] - 2017-02-23
+
 ### Fixed
+
 - `jquery-dollar-sign-reference` now checks assignments from `LogicalExpression` / `BinaryExpression`
 
 ## [15.1.1] - 2017-01-17
+
 ### Added
+
 - Added `eslint-index` package ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
 - Added `rules-status` and `rules-omitted` scripts ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
 - Added new `eslint-plugin-react` rules: `no-array-index-key`, `require-default-props` ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
@@ -842,13 +898,15 @@ Example:
 - Added new `eslint-plugin-promise` rules: `no-return-wrap`, `no-nesting`, `no-promise-in-callback`, `no-callback-in-promise`, `avoid-new`, `prefer-await-to-then`, `prefer-await-to-callbacks` ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
 
 ### Changed
+
 - Updated `eslint-plugin-flowtype`, `eslint-plugin-lodash`, `eslint-plugin-mocha`, `eslint-plugin-promise`, `eslint-plugin-react` to their latest versions ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
 - Updated `react/prefer-stateless-function` rule to include `ignorePureComponents` flag ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
 
 ### Removed
+
 - Removed `eslint-find-rules` package ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
 
-# Pre-15.1.1 Changelog
+## [15.1.0]
 
 Changes were originally tracked in Shopify's [JavaScript monorepo](https://github.com/Shopify/javascript/blob/f10bf7ddbdae07370cfe7c94617c450257731552/CHANGELOG.md).
 

--- a/packages/images/CHANGELOG.md
+++ b/packages/images/CHANGELOG.md
@@ -1,16 +1,21 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
 <!-- ## [Unreleased] -->
 
 ## [2.0.1] - 2020-03-28
 
 - Update internal dependencies and update tests ([#10](https://github.com/Shopify/images/pull/10))
 
-## 2.0.0 - 2019-06-03
+## [2.0.0] - 2019-06-03
 
 - Removed `removeDimensions` svg optimization ([#13](https://github.com/Shopify/images/pull/13))
 - Removed icon-loader and related SVGSource as we now use SVGr for loading icons ([#14](https://github.com/Shopify/images/pull/14))
 
-## 1.1.5 - 2018-05-04
+## [1.1.5] - 2018-05-04
 
 - CHANGELOG created

--- a/packages/postcss-plugin/CHANGELOG.md
+++ b/packages/postcss-plugin/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
 <!-- ## [Unreleased] -->
 
 ## [3.0.0] - 2020-03-28
@@ -8,8 +13,7 @@
 
 This package has been renamed from `postcss-shopify` to `@shopify/postcss-plugin.`. Update any configuration to use this new name
 
-
-### Before
+Before:
 
 ```
 module.exports = {
@@ -19,7 +23,8 @@ module.exports = {
 };
 ```
 
-#### After
+After:
+
 ```
 module.exports = {
   plugins: {
@@ -53,9 +58,11 @@ Breaking change: updated dependencies to use PostCSS 7.0.
 - Updated postcss-will-change: `^1.1.0` -> `^2.0.0` ([changelog](https://github.com/postcss/postcss-will-change/blob/master/CHANGELOG.md))
 
 ## [1.0.1] - 2018-01-17
+
 - Discard comments in the last processing step, allowing to use comments such as `/* autoprefixer: off */` ([#2](https://github.com/Shopify/postcss-shopify/pull/2))
 
-## 1.0.0 - 2017-03-05
+## [1.0.0] - 2017-03-05
+
 - Initial release
 
 [Unreleased]: https://github.com/Shopify/postcss-shopify/compare/v2.0.0...master

--- a/packages/stylelint-plugin/CHANGELOG.md
+++ b/packages/stylelint-plugin/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
 
 - Loosen the `selector-class-pattern` rule to allow for hypens in class names ([#153](https://github.com/Shopify/web-foundation/pull/153))
@@ -15,8 +20,7 @@
 
 This package has been renamed from `stylelint-config-shopify` to `@shopify/stylelint-plugin.`. Update any configuration to use this new name.
 
-
-### Before
+Before:
 
 ```
 "stylelint": {
@@ -24,7 +28,8 @@ This package has been renamed from `stylelint-config-shopify` to `@shopify/style
 }
 ```
 
-#### After
+After:
+
 ```
 "stylelint": {
   "extends": ["@shopify/stylelint-plugin/prettier"]
@@ -114,7 +119,7 @@ This package has been renamed from `stylelint-config-shopify` to `@shopify/style
 
 - Changed dependency: Use `stylelint-prettier` for prettier integration instead of `prettier-stylelint-formatter`. `stylelint-prettier` is a stylelint plugin that exposes prettier issues as stylelint rule violations. This means you can use `stylelint --fix` to fix formatting issues that prettier raises instead of having to use different executables for showing and autofixing issues.
 
-### Migration Suggestions
+Migration Suggestions:
 
 - If `stylelint-config-shopify/prettier` is used, please remove `prettier-stylelint-formatter` and update any scripts that referenced it to use run `stylelint --fix '**/*.scss'` to autofix issues.
 
@@ -151,7 +156,7 @@ The following patterns are _not_ considered violations:
 .foo::before { content: open-quote counter(section_counter) close-quote; }
 ```
 
-## [5.1.0] - 2018-07-05 [YANKED]
+## [5.1.0] - 2018-07-05
 
 - Use 5.1.1 instead.
 
@@ -170,7 +175,8 @@ The following patterns are _not_ considered violations:
 
 - Replaces [`prettier-stylelint`](https://github.com/hugomrdias/prettier-stylelint) with a [forked](https://github.com/ismail-syed/prettier-stylelint-formatter) version addressing an [issue](https://github.com/hugomrdias/prettier-stylelint/issues/3) [#23](https://github.com/Shopify/stylelint-config-shopify/pull/23)
 
-### Migration Suggestions
+Migration Suggestions:
+
 - If `stylelint-config-shopify/prettier` is used, please replace `prettier-stylelint` with `prettier-stylelint-formatter`.
 
     ```
@@ -188,14 +194,14 @@ The following patterns are _not_ considered violations:
 - Enforce property grouping, see [#10](https://github.com/Shopify/stylelint-config-shopify/pull/10)
 - Turn off `order/order` [#19](https://github.com/Shopify/stylelint-config-shopify/pull/19)
 
-### tl;dr
+tl;dr:
 
 - Put variables & custom properties at the top (unless anyone feels strongly about this)
 - Then come weird props, positioning & box model properties
 - All other properties come after
 - No specific property order is enforced
 
-### The following patterns are _not_ considered warnings:
+The following patterns are _not_ considered warnings:
 
 ```scss
 .Foo {
@@ -215,7 +221,7 @@ The following patterns are _not_ considered violations:
 }
 ```
 
-### The following patterns are considered warnings:
+The following patterns are considered warnings:
 
 ```scss
 .Foo {
@@ -232,21 +238,21 @@ The following patterns are _not_ considered violations:
   display: block;
 }
 ```
-
 
 ## [2.1.0] - 2017-08-25
 
-### Updated
-* [stylelint-scss](https://github.com/kristerkari/stylelint-scss) from `1.4.x` to `^2.0.1`
-* Replaced deprecated `scss/at-mixin-no-argumentless-call-parentheses` rule with its equivalent `scss/at-mixin-argumentless-call-parentheses`
-* `eslint-plugin-shopify` to the latest version, and updated ESLint to the appropriate version
 
 ### Changed
+
 * `media-feature-name-no-unknown` to ignore `prefers-reduced-motion`
+* [stylelint-scss](https://github.com/kristerkari/stylelint-scss) from `1.4.x` to `^2.0.1`
+* Replaced deprecated `scss/at-mixin-no-argumentless-call-parentheses` rule with its equivalent `scss/at-mixin-argumentless-call-parentheses`
+* Updated `eslint-plugin-shopify` to the latest version, and updated ESLint to the appropriate version
 
 ## [2.0.1] - 2017-07-28
 
 ### Changed
+
 * Set `selector-max-type` to 1
 
 ## [2.0.0] - 2017-07-27
@@ -293,9 +299,9 @@ The following patterns are _not_ considered violations:
 property: <top> <right> <bottom> <left>
 ```
 
-## 1.0.0 - 2017-05-29
-* Initial release
+## [1.0.0] - 2017-05-29
 
+* Initial release
 
 [Unreleased]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.4.0...HEAD
 [7.3.0]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.3.0...v7.4.0

--- a/packages/stylelint-plugin/README.md
+++ b/packages/stylelint-plugin/README.md
@@ -21,6 +21,7 @@ npm install stylelint @shopify/stylelint-plugin --save-dev
 
 
 ## Usage
+
 Shopify’s stylelint rules come bundled in `@shopify/stylelint-pluginv`. To enable these rules, add a `stylelint` property in your `package.json`. See the [stylelint configuration docs](https://stylelint.io/user-guide/configuration/) for more details.
 ```
 "stylelint": {

--- a/scripts/lint-changelogs.js
+++ b/scripts/lint-changelogs.js
@@ -1,0 +1,64 @@
+const {join, resolve} = require('path');
+
+const {readFileSync} = require('fs-extra');
+const glob = require('glob');
+
+const ROOT_PATH = resolve(__dirname, '..');
+
+const changelogs = readChangelogs();
+console.log(`🕵️‍♂️  Checking ${changelogs.length} changelogs`);
+
+const haveUnreleasedHeader = changelogs.filter(({packageChangelog}) =>
+  packageChangelog.split('\n').find((line) => /^## \[Unreleased\]/.exec(line)),
+);
+
+if (haveUnreleasedHeader.length > 0) {
+  console.error(
+    [
+      `❌ Found uncommented "## [Unreleased]" headers in one or more changelogs. These file(s) should be kept in-synch with the version(s) you are releasing. Update all changelogs to reflect the version you intend to release or the last released version and run yarn release again.`,
+      'Violations:',
+      ...haveUnreleasedHeader.map(
+        ({packageChangelogPath}) => `- ${packageChangelogPath}`,
+      ),
+    ].join('\n'),
+  );
+  process.exit(1);
+}
+
+console.log('✅ All changelogs are ready for release!');
+
+function readChangelogs() {
+  const packagesPath = join(ROOT_PATH, 'packages');
+
+  return glob
+    .sync(join(packagesPath, '*/'))
+    .filter(hasPackageJSON)
+    .map((packageDir) => {
+      const packageChangelogPath = join(packageDir, 'CHANGELOG.md');
+      const packageChangelog = safeReadSync(packageChangelogPath, {
+        encoding: 'utf8',
+      }).toString('utf-8');
+
+      return {
+        packageChangelogPath,
+        packageChangelog,
+      };
+    });
+}
+
+function safeReadSync(path, options) {
+  try {
+    return readFileSync(path, options);
+  } catch (err) {
+    return '';
+  }
+}
+
+function hasPackageJSON(packageDir) {
+  const packageJSONPath = join(packageDir, 'package.json');
+  const packageJSON = safeReadSync(packageJSONPath, {
+    encoding: 'utf8',
+  });
+
+  return packageJSON.length > 0;
+}

--- a/test/consistent-changelogs.test.js
+++ b/test/consistent-changelogs.test.js
@@ -1,0 +1,132 @@
+import {join, resolve} from 'path';
+
+import {readFileSync} from 'fs-extra';
+import glob from 'glob';
+
+const ROOT_PATH = resolve(__dirname, '..');
+
+const HEADER_START_REGEX = /^## /;
+const CHANGELOG_INTRO = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).`;
+
+readChangelogs().forEach(({packageChangelogPath, packageChangelog}) => {
+  describe(`changelog consistency for ${packageChangelogPath}`, () => {
+    it('begins with the "Keep a Changelog" intro section', () => {
+      const actualIntro = packageChangelog.substring(0, CHANGELOG_INTRO.length);
+
+      expect(actualIntro).toBe(CHANGELOG_INTRO);
+    });
+
+    it('contains only known headers', () => {
+      const headerLines = packageChangelog
+        .split('\n')
+        .filter((line) => /^\s*#/.exec(line));
+      const offendingHeaders = headerLines.filter(
+        (headerLine) => !headerIsAllowed(headerLine),
+      );
+
+      expect(offendingHeaders).toStrictEqual([]);
+    });
+
+    it('has exactly 1 empty line before headings', () => {
+      const notEnoughSpacingBeforeHeadings = /[^\n]+\n^#.*$/gm;
+
+      expect(packageChangelog).not.toStrictEqual(
+        expect.stringMatching(notEnoughSpacingBeforeHeadings),
+      );
+    });
+
+    it('has exactly 1 empty line after headings', () => {
+      const notEnoughSpacingAfterHeadings = /^#.*$\n[^\n]+/gm;
+
+      expect(packageChangelog).not.toStrictEqual(
+        expect.stringMatching(notEnoughSpacingAfterHeadings),
+      );
+    });
+
+    it('does not contain duplicate headers', () => {
+      const headerLines = packageChangelog
+        .split('\n')
+        .filter(
+          (line) =>
+            HEADER_START_REGEX.exec(line) || /## \[Unreleased\]/.exec(line),
+        )
+        .sort();
+      const uniqueHeaderLines = headerLines.filter(
+        (element, index, array) => array.indexOf(element) === index,
+      );
+
+      expect(headerLines).toStrictEqual(uniqueHeaderLines);
+    });
+  });
+});
+
+const allowedHeaders = [
+  '# Changelog',
+  '## [Unreleased]',
+  /^## \[\d+\.\d+\.\d+\] - \d\d\d\d-\d\d-\d\d$/,
+  // We should backfill dates using commit timestamps
+  /^## \[\d+\.\d+\.\d+\]$/,
+  '### Fixed',
+  '### Added',
+  '### Changed',
+  '### Deprecated',
+  '### Removed',
+  '### Security',
+  // This is technically not part of Keep a Changelog spec
+  '### Chore',
+  // This isn't part of it either
+  '### Breaking Change',
+  /^####/,
+];
+
+function headerIsAllowed(headerLine) {
+  return allowedHeaders.some((allowedHeader) => {
+    if (allowedHeader instanceof RegExp) {
+      return allowedHeader.test(headerLine);
+    } else {
+      return allowedHeader === headerLine;
+    }
+  });
+}
+
+function readChangelogs() {
+  const packagesPath = join(ROOT_PATH, 'packages');
+
+  return glob
+    .sync(join(packagesPath, '*/'))
+    .filter(hasPackageJSON)
+    .map((packageDir) => {
+      const packageChangelogPath = join(packageDir, 'CHANGELOG.md');
+      const packageChangelog = safeReadSync(packageChangelogPath, {
+        encoding: 'utf8',
+      }).toString('utf-8');
+
+      return {
+        packageDir,
+        packageChangelogPath,
+        packageChangelog,
+      };
+    });
+}
+
+function safeReadSync(path, options) {
+  try {
+    return readFileSync(path, options);
+  } catch {
+    return '';
+  }
+}
+
+function hasPackageJSON(packageDir) {
+  const packageJSONPath = join(packageDir, 'package.json');
+  const packageJSON = safeReadSync(packageJSONPath, {
+    encoding: 'utf8',
+  });
+
+  return packageJSON.length > 0;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1664,6 +1664,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
 atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
@@ -1807,11 +1812,6 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
-
-big.js@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
-  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
 binary-extensions@^1.0.0:
   version "1.13.1"
@@ -3050,11 +3050,6 @@ dom-serializer@0:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
-dom-walk@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
-  integrity sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=
-
 domelementtype@1, domelementtype@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
@@ -3148,11 +3143,6 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-emojis-list@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
-  integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
 end-of-stream@^1.1.0:
   version "1.4.4"
@@ -3696,7 +3686,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
+fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -3878,6 +3868,16 @@ fs-extra@^8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
+
+fs-extra@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.0.tgz#b6afc31036e247b2466dc99c29ae797d5d4580a3"
+  integrity sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^1.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -4094,14 +4094,6 @@ global-prefix@^3.0.0:
     ini "^1.3.5"
     kind-of "^6.0.2"
     which "^1.3.1"
-
-global@^4.3.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
-  integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
-  dependencies:
-    min-document "^2.19.0"
-    process "^0.11.10"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -4338,13 +4330,6 @@ hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
-
-hoist-non-react-statics@^3.3.0:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
-  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
-  dependencies:
-    react-is "^16.7.0"
 
 homedir-polyfill@^1.0.1:
   version "1.0.3"
@@ -5518,13 +5503,6 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
-  dependencies:
-    minimist "^1.2.0"
-
 json5@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.2.tgz#43ef1f0af9835dd624751a6b7fa48874fb2d608e"
@@ -5536,6 +5514,15 @@ jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.0.1.tgz#98966cba214378c8c84b82e085907b40bf614179"
+  integrity sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==
+  dependencies:
+    universalify "^1.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -5717,15 +5704,6 @@ load-json-file@^4.0.0:
     parse-json "^4.0.0"
     pify "^3.0.0"
     strip-bom "^3.0.0"
-
-loader-utils@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
-  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^3.0.0"
-    json5 "^1.0.1"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -6073,13 +6051,6 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
-
-min-document@^2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
-  integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
-  dependencies:
-    dom-walk "^0.1.0"
 
 min-indent@^1.0.0:
   version "1.0.0"
@@ -7375,11 +7346,6 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-process@^0.11.10:
-  version "0.11.10"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
-  integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
-
 progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -7393,7 +7359,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
-prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -7455,29 +7421,10 @@ rc@^1.0.1, rc@^1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-hot-loader@^4.6.0:
-  version "4.12.20"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.12.20.tgz#c2c42362a7578e5c30357a5ff7afa680aa0bef8a"
-  integrity sha512-lPlv1HVizi0lsi+UFACBJaydtRYILWkfHAC/lyCs6ZlAxlOZRQIfYHDqiGaRvL/GF7zyti+Qn9XpnDAUvdFA4A==
-  dependencies:
-    fast-levenshtein "^2.0.6"
-    global "^4.3.0"
-    hoist-non-react-statics "^3.3.0"
-    loader-utils "^1.1.0"
-    prop-types "^15.6.1"
-    react-lifecycles-compat "^3.0.4"
-    shallowequal "^1.1.0"
-    source-map "^0.7.3"
-
-react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.12.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react-lifecycles-compat@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
-  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
 react@^16.13.1:
   version "16.13.1"
@@ -8088,11 +8035,6 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
-
-shallowequal@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
-  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -9130,6 +9072,11 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
+  integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
 
 unquote@~1.1.1:
   version "1.1.1"


### PR DESCRIPTION
Ruthlessly stolen from https://github.com/Shopify/quilt/pull/1345

See that PR in quilt for technical info on what this does. But basically when you cut a release with `yarn release` it will shout at you if you forgot to update the changelogs to fixup `Unreleased` headings and replace them with actual numbers and release dates