### PR TITLE
Allow JSX on files with .jsx extension

### DIFF
--- a/packages/eslint-plugin/lib/config/rules/react.js
+++ b/packages/eslint-plugin/lib/config/rules/react.js
@@ -119,7 +119,7 @@ module.exports = {
   // Enforce or disallow spaces around equal signs in JSX attributes
   'react/jsx-equals-spacing': ['error', 'never'],
   // Restrict file extensions that may contain JSX
-  'react/jsx-filename-extension': ['error', {extensions: ['.js']}],
+  'react/jsx-filename-extension': ['error', {extensions: ['.jsx']}],
   // Enforce position of the first prop in JSX
   'react/jsx-first-prop-new-line': ['error', 'multiline'],
   // Enforce event handler naming conventions in JSX


### PR DESCRIPTION
Correct me if I'm wrong but the idea here would be to allow JSX in `.jsx` files, no?