### PR TITLE
[ESLint-plugin] Adds 'getDerivedStateFromError' to the list of React lifecycle methods to 'react-prefer-private-members'

### DIFF
--- a/packages/eslint-plugin/lib/rules/react-prefer-private-members.js
+++ b/packages/eslint-plugin/lib/rules/react-prefer-private-members.js
@@ -72,6 +72,7 @@ function isValid(node) {
 function isReactLifeCycleMethod({key: {name}}) {
   return [
     'getDerivedStateFromProps',
+    'getDerivedStateFromError',
     'componentWillMount',
     'UNSAFE_componentWillMount',
     'componentDidMount',

--- a/packages/eslint-plugin/tests/lib/rules/react-prefer-private-members.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/react-prefer-private-members.test.js
@@ -45,6 +45,7 @@ ruleTester.run('react-prefer-private-members', rule, {
         constructor() {}
         getChildContext() {}
         getDerivedStateFromProps() {}
+        getDerivedStateFromError() {}
         componentWillMount() {}
         UNSAFE_componentWillMount() {}
         componentDidMount() {}


### PR DESCRIPTION
Adds `getDerivedStateFromError` to the list of React lifecycle methods to `@shopify/react-prefer-private-members`.

Fixes https://github.com/Shopify/web-foundation/issues/167

To allow:
```ts
class ErrorBoundary extends Component<PropsWithChildren<Props>, State> {
  static getDerivedStateFromError() {
    return {hasError: true};
  }

  render() {
    ...
  }
}
```