### PR TITLE
Fix typo in Typescript Project References handbook

### DIFF
--- a/handbook/Best practices/TypeScript/Project-References.md
+++ b/handbook/Best practices/TypeScript/Project-References.md
@@ -30,7 +30,7 @@ TypeScript's documentation and guidance on [Project References](https://www.type
 
 In most large codebases, migrating to Project References in one go is likely, not feasible. The migration would have to be done gradually over time. 
 
-We recommend starting out but identifying the leaf nodes in your project's dependency graph. These leaf nodes generally include the most widely used parts of your codebase. A good place to start might be the `packages/`, `tests/` or `app/utilities`. 
+We recommend starting out by identifying the leaf nodes in your project's dependency graph. These leaf nodes generally include the most widely used parts of your codebase. A good place to start might be the `packages/`, `tests/` or `app/utilities`. 
 
 In our experience, we've noticed that some `app/utilities` may be tightly coupled with `tests` utilities, `app` code and `packages/` . In some cases even resulting in circular dependencies. We suggest you identifying some of the these utilities and extracting them into isolated project references hosted in `packages/@<project>-utilities`.
 

--- a/handbook/Best practices/TypeScript/README.md
+++ b/handbook/Best practices/TypeScript/README.md
@@ -18,10 +18,10 @@ This guide covers Shopify's approach to using TypeScript. It also highlights our
 
 Additional tooling is heavily integrated into TypeScript projects at Shopify to improve our development experience and developer confidence.
 
-* [`@shopify/typescript-configs`](https://github.com/Shopify/web-foundation/tree/master/packages/typescript-configs): Common base configuration files to simplify TypeScript project setup.
-* [`@shopify/eslint-plugin` TypeScript config](https://github.com/Shopify/web-foundation/blob/master/packages/eslint-plugin/lib/config/typescript.js) ESLint config for TypeScript codebases
-* [`graphql-typescript-definitions`](https://github.com/Shopify/graphql-tools-web/tree/master/packages/graphql-typescript-definitions): Tooling to generate TypeScript definition files from .graphql documents
-* [`@shopify/useful-types`](https://github.com/Shopify/quilt/tree/master/packages/useful-types): A few handy TypeScript types.
+* [`@shopify/typescript-configs`](https://github.com/Shopify/web-foundation/tree/main/packages/typescript-configs): Common base configuration files to simplify TypeScript project setup.
+* [`@shopify/eslint-plugin` TypeScript config](https://github.com/Shopify/web-foundation/blob/main/packages/eslint-plugin/lib/config/typescript.js) ESLint config for TypeScript codebases
+* [`graphql-typescript-definitions`](https://github.com/Shopify/graphql-tools-web/tree/main/packages/graphql-typescript-definitions): Tooling to generate TypeScript definition files from .graphql documents
+* [`@shopify/useful-types`](https://github.com/Shopify/quilt/tree/main/packages/useful-types): A few handy TypeScript types.
 
 ## Scaling large codebases
 


### PR DESCRIPTION
### Changes

- typo fix
- change `master` references to `main` for link to web-foundations configs.