### PR TITLE
Fix broken stuff caused by default branch rename

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -71,11 +71,11 @@ If your changes are complete in functionality, but you're not quite happy with a
 
 #### Feature branches
 
-Another option, if you'd like to break work down into reviewable chunks, is to use a feature branch. This would be an initially empty branch that contains the entirety of your feature. Additional units of work can be distributed across several PRs into the feature branch, merged independently, and then the feature branch can be merged as a complete unit into the master branch, when it's ready.
+Another option, if you'd like to break work down into reviewable chunks, is to use a feature branch. This would be an initially empty branch that contains the entirety of your feature. Additional units of work can be distributed across several PRs into the feature branch, merged independently, and then the feature branch can be merged as a complete unit into the `main` branch, when it's ready.
 
 ## Releasing
 
-The release process currently involves some manual steps to complete. Please ping Web Foundations ATC in the `#web-foundation-tech` Slack channel when you're ready to merge a new PR into `master`, and we will orchestrate a new release. The repo owner can follow [this guide](../docs/guides/release-and-deploy.md) to create a release.
+The release process currently involves some manual steps to complete. Please ping Web Foundations ATC in the `#web-foundation-tech` Slack channel when you're ready to merge a new PR into `main`, and we will orchestrate a new release. The repo owner can follow [this guide](../docs/guides/release-and-deploy.md) to create a release.
 
 **Note** Version numbers in `package.json` files should never be altered manually. This will be done via scripts as part of the release process.
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 # Web foundation
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=master)](https://travis-ci.com/Shopify/web-foundation)
-[![codecov](https://codecov.io/gh/Shopify/web-foundation/branch/master/graph/badge.svg)](https://codecov.io/gh/Shopify/web-foundation)
+[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
+[![codecov](https://codecov.io/gh/Shopify/web-foundation/branch/main/graph/badge.svg)](https://codecov.io/gh/Shopify/web-foundation)
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
 
 This repository contains common configuration and living [guidances](handbook) that Shopify uses to build web UI.

--- a/docs/guides/package-deprecation.md
+++ b/docs/guides/package-deprecation.md
@@ -29,7 +29,7 @@ run `yarn plop docs` to remove `{deprecated-package-name}` from the main README
 
 ## 5. Create your deprecation PR
 
-Create your PR with all the above changes and follow the normal PR review protocol to merge into master.
+Create your PR with all the above changes and follow the normal PR review protocol to merge into `main`.
 
 ## 6. Deprecate the package on npm
 

--- a/packages/babel-preset/README.md
+++ b/packages/babel-preset/README.md
@@ -1,6 +1,6 @@
 # `@shopify/babel-preset`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=master)](https://travis-ci.com/Shopify/web-foundation)
+[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fbabel-preset.svg)](https://badge.fury.io/js/%40shopify%2Fbabel-preset.svg)
 
 Shopify’s org-wide set of Babel transforms.

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -17,7 +17,7 @@
   "bugs": {
     "url": "https://github.com/Shopify/web-foundation/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/master/packages/babel-preset/README.md",
+  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/babel-preset/README.md",
   "dependencies": {
     "@babel/core": "^7.9.6",
     "@babel/plugin-proposal-class-properties": "^7.7.4",

--- a/packages/browserslist-config/README.md
+++ b/packages/browserslist-config/README.md
@@ -1,6 +1,6 @@
 # `@shopify/browserslist-config`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=master)](https://travis-ci.com/Shopify/web-foundation)
+[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fbrowserslist-config.svg)](https://badge.fury.io/js/%40shopify%2Fbrowserslist-config.svg)
 
 Shareable [browserslist](https://github.com/ai/browserslist) configuration for Shopify.

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/Shopify/web-foundation/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/master/packages/browserslist-config/README.md",
+  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/browserslist-config/README.md",
   "devDependencies": {
     "browserslist": "^4.3.4"
   }

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,6 +1,6 @@
 # `@shopify/eslint-plugin`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=master)](https://travis-ci.com/Shopify/web-foundation)
+[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Feslint-plugin.svg)](https://badge.fury.io/js/%40shopify%2Feslint-plugin.svg)
 
 Shopify’s ESLint rules and configs.

--- a/packages/eslint-plugin/docs/rules/jest/no-all-mocks-methods.md
+++ b/packages/eslint-plugin/docs/rules/jest/no-all-mocks-methods.md
@@ -32,4 +32,4 @@ jest.mock();
 
 ## Further Reading
 
-- [Shopify Jest Best Practices](https://github.com/Shopify/web-foundation/blob/master/handbook/Best%20practices/Jest.md#best-practices)
+- [Shopify Jest Best Practices](https://github.com/Shopify/web-foundation/blob/main/handbook/Best%20practices/Jest.md#best-practices)

--- a/packages/eslint-plugin/docs/rules/jest/no-snapshots.md
+++ b/packages/eslint-plugin/docs/rules/jest/no-snapshots.md
@@ -36,4 +36,4 @@ If you do not wish to prevent the use of jest snapshots, you can safely disable 
 
 ## Further Reading
 
-- [Shopify Jest Best Practices](https://github.com/Shopify/web-foundation/blob/master/handbook/Best%20practices/Jest.md#best-practices)
+- [Shopify Jest Best Practices](https://github.com/Shopify/web-foundation/blob/main/handbook/Best%20practices/Jest.md#best-practices)

--- a/packages/eslint-plugin/lib/rules/jest/no-all-mocks-methods.js
+++ b/packages/eslint-plugin/lib/rules/jest/no-all-mocks-methods.js
@@ -5,7 +5,7 @@ module.exports = {
       category: 'Best Practices',
       recommended: false,
       uri:
-        'https://github.com/Shopify/web-foundation/blob/master/packages/eslint-plugin/docs/rules/jest/no-all-mocks-methods.md',
+        'https://github.com/Shopify/web-foundation/blob/main/packages/eslint-plugin/docs/rules/jest/no-all-mocks-methods.md',
     },
   },
   messages: {

--- a/packages/eslint-plugin/lib/utilities/index.js
+++ b/packages/eslint-plugin/lib/utilities/index.js
@@ -137,7 +137,7 @@ function getRootObject(memberExpression) {
 }
 
 function docsUrl(ruleName) {
-  return `${REPO_URL}/blob/master/packages/eslint-plugin/docs/rules/${ruleName}.md`;
+  return `${REPO_URL}/blob/main/packages/eslint-plugin/docs/rules/${ruleName}.md`;
 }
 
 module.exports = {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -23,7 +23,7 @@
   "bugs": {
     "url": "https://github.com/Shopify/web-foundation/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/master/packages/eslint-plugin/README.md",
+  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/eslint-plugin/README.md",
   "devDependencies": {
     "graphql": "^14.6.0",
     "react": "^16.13.1",

--- a/packages/eslint-plugin/tests/lib/utilities.test.js
+++ b/packages/eslint-plugin/tests/lib/utilities.test.js
@@ -4,19 +4,19 @@ describe('utilities', () => {
   describe('docsUrl()', () => {
     it('returns the repo documentation url when given a rule name', () => {
       expect(docsUrl('some-fake-rule')).toBe(
-        'https://github.com/Shopify/web-foundation/blob/master/packages/eslint-plugin/docs/rules/some-fake-rule.md',
+        'https://github.com/Shopify/web-foundation/blob/main/packages/eslint-plugin/docs/rules/some-fake-rule.md',
       );
       expect(docsUrl('another-fake-rule')).toBe(
-        'https://github.com/Shopify/web-foundation/blob/master/packages/eslint-plugin/docs/rules/another-fake-rule.md',
+        'https://github.com/Shopify/web-foundation/blob/main/packages/eslint-plugin/docs/rules/another-fake-rule.md',
       );
     });
 
     it('returns the repo documentation url when given a prefixed rule name', () => {
       expect(docsUrl('jest/some-fake-rule')).toBe(
-        'https://github.com/Shopify/web-foundation/blob/master/packages/eslint-plugin/docs/rules/jest/some-fake-rule.md',
+        'https://github.com/Shopify/web-foundation/blob/main/packages/eslint-plugin/docs/rules/jest/some-fake-rule.md',
       );
       expect(docsUrl('typescript/another-fake-rule')).toBe(
-        'https://github.com/Shopify/web-foundation/blob/master/packages/eslint-plugin/docs/rules/typescript/another-fake-rule.md',
+        'https://github.com/Shopify/web-foundation/blob/main/packages/eslint-plugin/docs/rules/typescript/another-fake-rule.md',
       );
     });
   });

--- a/packages/images/README.md
+++ b/packages/images/README.md
@@ -1,6 +1,6 @@
 # `@shopify/images`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=master)](https://travis-ci.com/Shopify/web-foundation)
+[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fimages.svg)](https://badge.fury.io/js/%40shopify%2Fimages.svg)
 
 Tools to help us wrangle images at Shopify.

--- a/packages/images/package.json
+++ b/packages/images/package.json
@@ -17,7 +17,7 @@
   "bugs": {
     "url": "https://github.com/Shopify/web-foundation/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/master/packages/images/README.md",
+  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/images/README.md",
   "devDependencies": {
     "svgo": "^1.3.2"
   }

--- a/packages/postcss-plugin/README.md
+++ b/packages/postcss-plugin/README.md
@@ -1,6 +1,6 @@
 # `@shopify/postcss-plugin`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=master)](https://travis-ci.com/Shopify/web-foundation)
+[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fpostcss-plugin.svg)](https://badge.fury.io/js/%40shopify%2Fpostcss-plugin.svg)
 
 All of Shopify’s preferred [PostCSS](https://github.com/postcss/postcss) plugins wrapped up in a single, easy-to-use plugin.

--- a/packages/postcss-plugin/package.json
+++ b/packages/postcss-plugin/package.json
@@ -23,7 +23,7 @@
   "bugs": {
     "url": "https://github.com/Shopify/web-foundation/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/master/packages/postcss-plugin/README.md",
+  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/postcss-plugin/README.md",
   "dependencies": {
     "autoprefixer": "9.3.1",
     "cssnano": "^4.1.7",

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -1,7 +1,7 @@
 # `@shopify/prettier-config`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=master)](https://travis-ci.com/Shopify/web-foundation)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fprettier-config.svg)](https://badge.fury.io/js/%40shopify%2Fprettier-config.svg)  [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/prettier-config.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/prettier-config.svg) 
+[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fprettier-config.svg)](https://badge.fury.io/js/%40shopify%2Fprettier-config.svg)  [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/prettier-config.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/prettier-config.svg)
 
 Shared prettier configuration
 

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -18,5 +18,5 @@
   "bugs": {
     "url": "https://github.com/Shopify/web-foundation/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/master/packages/prettier-config/README.md"
+  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/prettier-config/README.md"
 }

--- a/packages/stylelint-plugin/README.md
+++ b/packages/stylelint-plugin/README.md
@@ -1,6 +1,6 @@
 # `@shopify/stylelint-plugin`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=master)](https://travis-ci.com/Shopify/web-foundation)
+[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fstylelint-plugin.svg)](https://badge.fury.io/js/%40shopify%2Fstylelint-plugin.svg)
 
 Shopify's stylelint rules and config

--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -23,7 +23,7 @@
   "bugs": {
     "url": "https://github.com/Shopify/web-foundation/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/master/packages/stylelint-plugin/README.md",
+  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/stylelint-plugin/README.md",
   "dependencies": {
     "merge": "^1.2.1",
     "stylelint-config-prettier": "^8.0.1",

--- a/packages/typescript-configs/README.md
+++ b/packages/typescript-configs/README.md
@@ -1,6 +1,6 @@
 # `@shopify/typescript-configs`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=master)](https://travis-ci.com/Shopify/web-foundation)
+[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Ftypescript-configs.svg)](https://badge.fury.io/js/%40shopify%2Ftypescript-configs.svg)
 
 In TypeScript, the configuration file can extend from a base file. This package provided a few common base configuration files to simplify TypeScript project setup.

--- a/packages/typescript-configs/package.json
+++ b/packages/typescript-configs/package.json
@@ -16,5 +16,5 @@
   "bugs": {
     "url": "https://github.com/Shopify/web-foundation/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/master/packages/typescript-configs/README.md"
+  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/typescript-configs/README.md"
 }

--- a/templates/README.hbs.md
+++ b/templates/README.hbs.md
@@ -1,6 +1,6 @@
 # `@shopify/{{name}}`
 
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=master)](https://travis-ci.com/Shopify/web-foundation)
+[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2F{{name}}.svg)](https://badge.fury.io/js/%40shopify%2F{{name}}.svg) {{#if usedInBrowser}} [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/{{name}}.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/{{name}}.svg) {{/if}}
 
 {{description}}

--- a/templates/ROOT_README.hbs.md
+++ b/templates/ROOT_README.hbs.md
@@ -5,8 +5,8 @@
 # Web foundation
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=master)](https://travis-ci.com/Shopify/web-foundation)
-[![codecov](https://codecov.io/gh/Shopify/web-foundation/branch/master/graph/badge.svg)](https://codecov.io/gh/Shopify/web-foundation)
+[![Build Status](https://travis-ci.com/Shopify/web-foundation.svg?branch=main)](https://travis-ci.com/Shopify/web-foundation)
+[![codecov](https://codecov.io/gh/Shopify/web-foundation/branch/main/graph/badge.svg)](https://codecov.io/gh/Shopify/web-foundation)
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
 
 This repository contains common configuration and living [guidances](handbook) that Shopify uses to build web UI.

--- a/templates/package.hbs.json
+++ b/templates/package.hbs.json
@@ -18,6 +18,6 @@
   "bugs": {
     "url": "https://github.com/Shopify/web-foundation/issues"
   },
-  "homepage": "https://github.com/Shopify/web-foundation/blob/master/packages/{{name}}/README.md",
+  "homepage": "https://github.com/Shopify/web-foundation/blob/main/packages/{{name}}/README.md",
   "dependencies": {}
 }


### PR DESCRIPTION
The default branch was changed from `master` to `main`, which broke all the links, badges, and also the `docsUrl` function.