### PR TITLE
Prefer buildClientSchema to buildSchema

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -9,6 +9,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Created a new rule, `@shopify/typescript/prefer-build-client-schema` ([#176](https://github.com/Shopify/web-foundation/pull/176))
+
 ### Breaking Change
 
 - Dropping `eslint-plugin-typescript` and upgrading `@typescript-eslint/eslint-plugin` from `2.33.0` to `3.9.1`. The update brings breaking changes from [the version 3 release of `@typescript-eslint/eslint-plugin`](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v3.0.0).

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -155,4 +155,5 @@ This plugin provides the following custom rules, which are included as appropria
 - [strict-component-boundaries](docs/rules/strict-component-boundaries.md): Prevent module imports between components.
 - [typescript/prefer-pascal-case-enums](docs/rules/typescript/prefer-pascal-case-enums.md): Prefer TypeScript enums be defined using Pascal case.
 - [typescript/prefer-singular-enums](docs/rules/typescript/prefer-singular-enums.md): Prefer TypeScript enums be singular.
+- [typescript/prefer-build-client-schema](docs/rules/typescript/prefer-build-client-schema.md): Prefer buildClientSchema for schema building.
 - [webpack/no-unnamed-dynamic-imports](docs/rules/webpack/no-unnamed-dynamic-imports.md): Require that all dynamic imports contain a `webpackChunkName` comment.

--- a/packages/eslint-plugin/docs/rules/typescript/prefer-build-client-schema.md
+++ b/packages/eslint-plugin/docs/rules/typescript/prefer-build-client-schema.md
@@ -1,0 +1,44 @@
+# Prefer buildClientSchema (typescript/prefer-build-client-schema)
+
+Enforces [buildClientSchema](https://graphql.org/graphql-js/utilities/#buildclientschema) to `buildSchema` for performance within TypeScript code.
+
+## Rule Details
+
+This rule recommends all schema building through `buildClientSchema` as opposed to `buildSchema`. A warning will occur if the `buildSchema` is used.
+
+The difference between both is that [buildClientSchema](https://graphql.org/graphql-js/utilities/#buildclientschema) uses the result from the introspection query (`.json`) to build the schema whereas [buildSchema](https://graphql.org/graphql-js/utilities/#buildschema) uses the GraphQL schema language file (`.grapqhl`) to create the GraphQL schema instance.
+
+Examples of **incorrect** code for this rule:
+
+```ts
+import {buildSchema} from 'graphql';
+
+export function loadSchemaAndTypes(projectName: string) {
+  return {
+    schema: buildSchema(
+      readFileSync(resolve(basePath, `${projectName}.graphql`), 'utf8'),
+    ),
+    ...
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+import {buildClientSchema} from 'graphql';
+
+export function loadSchemaAndTypes(projectName: string) {
+  return {
+    schema: buildClientSchema(
+      JSON.parse(readFileSync(resolve(basePath, `${projectName}.json`), 'utf8'))
+        .data,
+    ),
+    ...
+  }
+}
+```
+
+## When Not To Use It
+
+If you have clear reason for using `buildSchema` and understand the performance tradeoffs, you can safely disable this rule.

--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -30,6 +30,7 @@ module.exports = {
     'strict-component-boundaries': require('./lib/rules/strict-component-boundaries'),
     'typescript/prefer-pascal-case-enums': require('./lib/rules/typescript/prefer-pascal-case-enums'),
     'typescript/prefer-singular-enums': require('./lib/rules/typescript/prefer-singular-enums'),
+    'typescript/prefer-build-client-schema': require('./lib/rules/typescript/prefer-build-client-schema'),
     'webpack/no-unnamed-dynamic-imports': require('./lib/rules/webpack/no-unnamed-dynamic-imports'),
   },
 

--- a/packages/eslint-plugin/lib/config/rules/shopify.js
+++ b/packages/eslint-plugin/lib/config/rules/shopify.js
@@ -59,6 +59,8 @@ module.exports = {
   '@shopify/typescript/prefer-pascal-case-enums': 'off',
   // Enforces all TypeScript enums to be singular
   '@shopify/typescript/prefer-singular-enums': 'off',
+  // Prefer buildClientSchema for schema building.
+  '@shopify/typescript/prefer-build-client-schema': 'error',
   // Require that all dynamic imports contain a `webpackChunkName` comment.
   '@shopify/webpack/no-unnamed-dynamic-imports': 'off',
 };

--- a/packages/eslint-plugin/lib/config/typescript.js
+++ b/packages/eslint-plugin/lib/config/typescript.js
@@ -67,6 +67,8 @@ module.exports = {
         '@shopify/typescript/prefer-pascal-case-enums': 'error',
         // Prefer TypeScript enums be defined using singular names
         '@shopify/typescript/prefer-singular-enums': 'error',
+        // Prefer buildClientSchema for schema building.
+        '@shopify/typescript/prefer-build-client-schema': 'error',
       }),
     },
   ],

--- a/packages/eslint-plugin/lib/rules/typescript/prefer-build-client-schema.js
+++ b/packages/eslint-plugin/lib/rules/typescript/prefer-build-client-schema.js
@@ -1,0 +1,33 @@
+const {docsUrl} = require('../../utilities');
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Prefer buildClientSchema for schema building',
+      category: 'Best Practices',
+      recommended: true,
+      uri: docsUrl('typescript/prefer-build-client-schema'),
+    },
+    fixable: null,
+  },
+  create(context) {
+    function report(node) {
+      context.report({
+        node,
+        message: `Prefer buildClientSchema to buildSchema`,
+      });
+    }
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === 'graphql') {
+          node.specifiers.forEach((spec) => {
+            if (spec.imported.name === 'buildSchema') {
+              report(node);
+            }
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/tests/lib/rules/typescript/prefer-build-client-schema.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/typescript/prefer-build-client-schema.test.js
@@ -1,0 +1,49 @@
+const {RuleTester} = require('eslint');
+
+const rule = require('../../../../lib/rules/typescript/prefer-build-client-schema');
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+function error() {
+  return {
+    message: 'Prefer buildClientSchema to buildSchema',
+  };
+}
+
+ruleTester.run('prefer-build-client-schema', rule, {
+  valid: [
+    {
+      code: `import {foo} from 'bar';`,
+    },
+    {
+      code: `import {foo} from 'graphql';`,
+    },
+    {
+      code: `import {buildSchema} from 'foo';`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import {buildSchema} from 'graphql';`,
+      errors: [error()],
+    },
+    {
+      code: `import {foo, buildSchema} from 'graphql';`,
+      errors: [error()],
+    },
+    {
+      code: `import {buildSchema, bar} from 'graphql';`,
+      errors: [error()],
+    },
+    {
+      code: `import {buildSchema as foo} from 'graphql';`,
+      errors: [error()],
+    },
+  ],
+});


### PR DESCRIPTION
Added a new rule, `@shopify/typescript/prefer-build-client-schema`, which flags uses of `buildSchema` and recommends using `buildClientSchema` instead due to our findings in performance.

For more information on the performance findings, check [here](https://github.com/Shopify/web/pull/30292).