### PR TITLE
Update polaris-no-bare-stack-item.md

### DIFF
--- a/packages/eslint-plugin/docs/rules/polaris-no-bare-stack-item.md
+++ b/packages/eslint-plugin/docs/rules/polaris-no-bare-stack-item.md
@@ -23,7 +23,7 @@ The following patterns are not warnings:
 ```js
 import {Stack} from '@shopify/polaris';
 
-<Stack.Item fill>Content</Stack.Item>
-<Stack>No wrapping item</Stack>
+<Stack.Item fill><span>Content</span></Stack.Item>
+<Stack><span>No wrapping item</span></Stack>
 ```
 


### PR DESCRIPTION
Stack doesn't wrap `strings` with items automatically. So we shouldn't use strings in our examples.
The children have to be valid react elements, and a string is not an element.